### PR TITLE
Feat/ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Cargo check
+        run: cargo check --workspace --all-targets
+
+      - name: Cargo test
+        run: cargo test --workspace --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,17 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
 
       - name: Cache Cargo build artifacts
         uses: Swatinem/rust-cache@v2
+
+      - name: Cargo fmt (check)
+        run: cargo fmt --all -- --check
+
+      - name: Cargo clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: Cargo check
         run: cargo check --workspace --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache Cargo build artifacts
+        if: ${{ !env.ACT }}
         uses: Swatinem/rust-cache@v2
 
       - name: Cargo fmt (check)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: ci
+
+ACT ?= act
+ACT_ARCH ?= linux/amd64
+ACT_JOB ?= check-and-test
+
+ci:
+	@command -v $(ACT) >/dev/null || { echo "act command not found"; exit 1; }
+	$(ACT) --container-architecture $(ACT_ARCH) -j $(ACT_JOB) --env ACT=true

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ The name is inspired by *reinforcing bar* ("rebar"), with the project-specific s
 
 Work in progress.
 
+## Local CI
+
+Run the same `check-and-test` job as GitHub Actions with one command:
+
+```bash
+make ci
+```
+
 ## Layers
 
 - `api/`: user-facing API layer

--- a/api/op/src/at.rs
+++ b/api/op/src/at.rs
@@ -1,5 +1,5 @@
-use dense_impl::ops::at::DenseAtError;
 use dense_impl::DenseOps;
+use dense_impl::ops::at::DenseAtError;
 use execution::ExecutionTag;
 use op_contracts::{ReadAtOp, Scalar, WriteAtOp};
 use tensor::Tensor;
@@ -29,9 +29,9 @@ pub fn at(tensor: &Tensor, indices: &[usize]) -> Result<Scalar, AtError> {
 /// Write a single element at the given indices. CPU tensors only.
 pub fn set_at(tensor: &mut Tensor, indices: &[usize], value: Scalar) -> Result<(), SetAtError> {
     match tensor {
-        Tensor::Dense(dense) if dense.execution_tag() == ExecutionTag::Cpu => {
-            DenseOps.write_at(dense, indices, value).map_err(SetAtError::Dense)
-        }
+        Tensor::Dense(dense) if dense.execution_tag() == ExecutionTag::Cpu => DenseOps
+            .write_at(dense, indices, value)
+            .map_err(SetAtError::Dense),
         _ => Err(SetAtError::NotOnHost),
     }
 }

--- a/api/op/src/fill.rs
+++ b/api/op/src/fill.rs
@@ -17,7 +17,9 @@ pub enum FillError {
 /// Fill all elements of `tensor` in-place with `value`.
 pub fn fill(tensor: &mut Tensor, value: f32) -> Result<(), FillError> {
     match tensor {
-        Tensor::Dense(dense) => DenseOps.fill_inplace(dense, value).map_err(FillError::Dense),
+        Tensor::Dense(dense) => DenseOps
+            .fill_inplace(dense, value)
+            .map_err(FillError::Dense),
     }
 }
 

--- a/api/op/src/lib.rs
+++ b/api/op/src/lib.rs
@@ -2,9 +2,9 @@ pub mod at;
 pub mod fill;
 pub mod narrow;
 
-pub use at::{at, set_at, AtError, SetAtError};
-pub use fill::{fill, fill_new, Fill, FillError};
-pub use narrow::{narrow, NarrowError};
+pub use at::{AtError, SetAtError, at, set_at};
+pub use fill::{Fill, FillError, fill, fill_new};
+pub use narrow::{NarrowError, narrow};
 pub use op_contracts::Scalar;
 
 #[cfg(test)]

--- a/api/op/src/narrow.rs
+++ b/api/op/src/narrow.rs
@@ -1,5 +1,5 @@
-use dense_impl::ops::narrow::DenseNarrowError;
 use dense_impl::DenseOps;
+use dense_impl::ops::narrow::DenseNarrowError;
 use op_contracts::NarrowOp;
 use tensor::Tensor;
 
@@ -10,7 +10,12 @@ pub enum NarrowError {
 
 /// Return a view of `tensor` along `dim`, starting at element `start` with length `len`.
 /// Available for all backends; the returned tensor shares the underlying storage.
-pub fn narrow(tensor: &Tensor, dim: usize, start: usize, len: usize) -> Result<Tensor, NarrowError> {
+pub fn narrow(
+    tensor: &Tensor,
+    dim: usize,
+    start: usize,
+    len: usize,
+) -> Result<Tensor, NarrowError> {
     match tensor {
         Tensor::Dense(dense) => DenseOps
             .narrow(dense, dim, start, len)

--- a/api/tensor/src/builder.rs
+++ b/api/tensor/src/builder.rs
@@ -1,4 +1,4 @@
-use dense_impl::{DenseBuilder, DenseBuildError};
+use dense_impl::{DenseBuildError, DenseBuilder};
 
 use crate::tag::TensorTag;
 use crate::tensor::Tensor;

--- a/api/tensor/src/lib.rs
+++ b/api/tensor/src/lib.rs
@@ -2,7 +2,7 @@ mod builder;
 mod tag;
 mod tensor;
 
-pub use builder::{TensorBuilder, TensorBuildError};
+pub use builder::{TensorBuildError, TensorBuilder};
 pub use tag::TensorTag;
 pub use tensor::Tensor;
 

--- a/core/dense_impl/src/lib.rs
+++ b/core/dense_impl/src/lib.rs
@@ -2,7 +2,7 @@ mod builder;
 pub mod ops;
 mod tensor;
 
-pub use builder::{DenseBuilder, DenseBuildError};
+pub use builder::{DenseBuildError, DenseBuilder};
 pub use ops::DenseOps;
 pub use tensor::DenseTensorImpl;
 
@@ -11,7 +11,7 @@ mod tests {
     use execution::ExecutionTag;
     use op_contracts::FillOp;
 
-    use super::{ops::DenseOps, DenseBuilder, DenseBuildError};
+    use super::{DenseBuildError, DenseBuilder, ops::DenseOps};
 
     #[test]
     fn build_then_fill() {
@@ -19,7 +19,9 @@ mod tests {
             .build()
             .expect("dense build should succeed");
 
-        DenseOps.fill_inplace(&mut tensor, 1.5).expect("fill should succeed");
+        DenseOps
+            .fill_inplace(&mut tensor, 1.5)
+            .expect("fill should succeed");
 
         assert_eq!(tensor.shape(), &[2, 3]);
         assert_eq!(tensor.strides(), &[3, 1]);
@@ -44,7 +46,9 @@ mod tests {
             .build()
             .expect("dense build should succeed");
 
-        DenseOps.fill_inplace(&mut tensor, 9.5).expect("fill op should succeed");
+        DenseOps
+            .fill_inplace(&mut tensor, 9.5)
+            .expect("fill op should succeed");
         assert_eq!(tensor.data(), vec![9.5, 9.5, 9.5, 9.5]);
     }
 

--- a/core/dense_impl/src/ops/at.rs
+++ b/core/dense_impl/src/ops/at.rs
@@ -1,6 +1,8 @@
 use std::sync::{Mutex, OnceLock};
 
-use execution::{CpuKernelArgs, KernelArgs, Storage, StorageAllocError, StorageContext, StorageRequest};
+use execution::{
+    CpuKernelArgs, KernelArgs, Storage, StorageAllocError, StorageContext, StorageRequest,
+};
 use op_contracts::Scalar;
 use runtime::{
     DispatchApi, DispatchError, Dispatcher, KernelRegistryConfig, KeyVersion, OpTag, SeedSpec,
@@ -52,9 +54,9 @@ pub fn exec_read(tensor: &DenseTensorImpl, indices: &[usize]) -> Result<Scalar, 
         .dispatch_seed(seed, &args)
         .map_err(DenseAtError::Dispatch)?;
 
-    let value = out_cpu.buffer().with_read_bytes(|bytes| {
-        f32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
-    });
+    let value = out_cpu
+        .buffer()
+        .with_read_bytes(|bytes| f32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]));
 
     Ok(Scalar::F32(value))
 }
@@ -108,8 +110,15 @@ pub fn exec_write(
 
 #[derive(Debug)]
 pub enum DenseAtError {
-    RankMismatch { expected: usize, actual: usize },
-    IndexOutOfBounds { dim: usize, index: usize, size: usize },
+    RankMismatch {
+        expected: usize,
+        actual: usize,
+    },
+    IndexOutOfBounds {
+        dim: usize,
+        index: usize,
+        size: usize,
+    },
     UnsupportedScalar(Scalar),
     StorageAlloc(StorageAllocError),
     KernelArgs(schema::KernelArgsError),
@@ -147,7 +156,11 @@ fn validated_pos(tensor: &DenseTensorImpl, indices: &[usize]) -> Result<usize, D
     }
     for (dim, (&idx, &size)) in indices.iter().zip(shape.iter()).enumerate() {
         if idx >= size {
-            return Err(DenseAtError::IndexOutOfBounds { dim, index: idx, size });
+            return Err(DenseAtError::IndexOutOfBounds {
+                dim,
+                index: idx,
+                size,
+            });
         }
     }
     let pos = tensor.offset()

--- a/core/dense_impl/src/ops/narrow.rs
+++ b/core/dense_impl/src/ops/narrow.rs
@@ -39,8 +39,16 @@ pub fn exec(
 
 #[derive(Debug)]
 pub enum DenseNarrowError {
-    DimOutOfBounds { dim: usize, ndim: usize },
-    RangeOutOfBounds { dim: usize, start: usize, len: usize, size: usize },
+    DimOutOfBounds {
+        dim: usize,
+        ndim: usize,
+    },
+    RangeOutOfBounds {
+        dim: usize,
+        start: usize,
+        len: usize,
+        size: usize,
+    },
 }
 
 impl op_contracts::NarrowOp<DenseTensorImpl> for super::DenseOps {

--- a/core/dense_impl/src/tensor.rs
+++ b/core/dense_impl/src/tensor.rs
@@ -67,18 +67,31 @@ impl DenseTensorImpl {
     pub fn read_all_f32(&self) -> Vec<f32> {
         let numel = self.numel();
         let mut result = Vec::with_capacity(numel);
+        let is_contiguous = self.strides == contiguous_strides(&self.shape);
         match &self.storage {
             Storage::Cpu(storage) => {
                 storage.buffer().with_read_bytes(|bytes| {
-                    for i in 0..numel {
-                        let pos = flat_to_pos(i, &self.shape, &self.strides, self.offset);
-                        let b = pos * 4;
-                        result.push(f32::from_ne_bytes([
-                            bytes[b],
-                            bytes[b + 1],
-                            bytes[b + 2],
-                            bytes[b + 3],
-                        ]));
+                    if is_contiguous {
+                        for i in 0..numel {
+                            let b = (self.offset + i) * std::mem::size_of::<f32>();
+                            result.push(f32::from_ne_bytes([
+                                bytes[b],
+                                bytes[b + 1],
+                                bytes[b + 2],
+                                bytes[b + 3],
+                            ]));
+                        }
+                    } else {
+                        for i in 0..numel {
+                            let pos = flat_to_pos(i, &self.shape, &self.strides, self.offset);
+                            let b = pos * std::mem::size_of::<f32>();
+                            result.push(f32::from_ne_bytes([
+                                bytes[b],
+                                bytes[b + 1],
+                                bytes[b + 2],
+                                bytes[b + 3],
+                            ]));
+                        }
                     }
                 });
             }
@@ -117,18 +130,31 @@ impl DenseTensorImpl {
     pub fn data(&self) -> Vec<f32> {
         let numel = self.numel();
         let mut result = Vec::with_capacity(numel);
+        let is_contiguous = self.strides == contiguous_strides(&self.shape);
         match &self.storage {
             Storage::Cpu(storage) => {
                 storage.buffer().with_read_bytes(|bytes| {
-                    for i in 0..numel {
-                        let pos = flat_to_pos(i, &self.shape, &self.strides, self.offset);
-                        let b = pos * 4;
-                        result.push(f32::from_ne_bytes([
-                            bytes[b],
-                            bytes[b + 1],
-                            bytes[b + 2],
-                            bytes[b + 3],
-                        ]));
+                    if is_contiguous {
+                        for i in 0..numel {
+                            let b = (self.offset + i) * std::mem::size_of::<f32>();
+                            result.push(f32::from_ne_bytes([
+                                bytes[b],
+                                bytes[b + 1],
+                                bytes[b + 2],
+                                bytes[b + 3],
+                            ]));
+                        }
+                    } else {
+                        for i in 0..numel {
+                            let pos = flat_to_pos(i, &self.shape, &self.strides, self.offset);
+                            let b = pos * std::mem::size_of::<f32>();
+                            result.push(f32::from_ne_bytes([
+                                bytes[b],
+                                bytes[b + 1],
+                                bytes[b + 2],
+                                bytes[b + 3],
+                            ]));
+                        }
                     }
                 });
             }

--- a/core/dense_impl/src/tensor.rs
+++ b/core/dense_impl/src/tensor.rs
@@ -11,7 +11,12 @@ pub struct DenseTensorImpl {
 impl DenseTensorImpl {
     pub(crate) fn new(shape: Vec<usize>, storage: Storage) -> Self {
         let strides = contiguous_strides(&shape);
-        Self { shape, strides, offset: 0, storage }
+        Self {
+            shape,
+            strides,
+            offset: 0,
+            storage,
+        }
     }
 
     pub(crate) fn with_view(
@@ -20,7 +25,12 @@ impl DenseTensorImpl {
         offset: usize,
         storage: Storage,
     ) -> Self {
-        Self { shape, strides, offset, storage }
+        Self {
+            shape,
+            strides,
+            offset,
+            storage,
+        }
     }
 
     pub fn shape(&self) -> &[usize] {

--- a/execution/src/kernel/mod.rs
+++ b/execution/src/kernel/mod.rs
@@ -103,7 +103,7 @@ mod tests {
         args: &CpuKernelArgs,
         _launch_config: &CpuKernelLaunchConfig,
     ) -> Result<(), CpuKernelLaunchError> {
-        if args.len() == 0 {
+        if args.is_empty() {
             return Ok(());
         }
         KERNEL_CALL_COUNT.fetch_add(1, Ordering::SeqCst);

--- a/execution/src/storage/mod.rs
+++ b/execution/src/storage/mod.rs
@@ -154,7 +154,7 @@ mod tests {
     }
 
     fn encode_f32_slice(values: &[f32]) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(values.len() * std::mem::size_of::<f32>());
+        let mut bytes = Vec::with_capacity(std::mem::size_of_val(values));
         for value in values {
             bytes.extend_from_slice(&value.to_ne_bytes());
         }

--- a/execution_contracts/src/bundle.rs
+++ b/execution_contracts/src/bundle.rs
@@ -12,10 +12,10 @@ pub trait BackendBundle {
     type StorageAllocError: Clone + PartialEq + Eq;
     type KernelMetadata: ExecutionKernelMetadata<Launcher = Self::KernelLauncher>;
     type KernelLauncher: ExecutionKernelLauncher<
-        Metadata = Self::KernelMetadata,
-        Args = Self::KernelArgs,
-        Error = Self::LaunchError,
-    >;
+            Metadata = Self::KernelMetadata,
+            Args = Self::KernelArgs,
+            Error = Self::LaunchError,
+        >;
     type KernelContext: ExecutionKernelContext + Default + PartialEq + Eq;
     type KernelArgs: ExecutionKernelArgs;
     type Capability: ExecutionCapability + Default + PartialEq + Eq;

--- a/execution_cpu/src/kernel/cpu/fill.rs
+++ b/execution_cpu/src/kernel/cpu/fill.rs
@@ -41,19 +41,22 @@ pub fn launch(
         )));
     }
 
-    out_storage.buffer().with_write_bytes(|out| {
-        if out.len() % std::mem::size_of::<f32>() != 0 {
-            return Err(CpuKernelLaunchError::new(
-                "cpu.fill requires output byte-size to be multiple of f32 size",
-            ));
-        }
+    let element_bytes = std::mem::size_of::<f32>();
+    out_storage
+        .buffer()
+        .with_write_bytes(|out| -> Result<(), CpuKernelLaunchError> {
+            if out.len() % element_bytes != 0 {
+                return Err(CpuKernelLaunchError::new(
+                    "cpu.fill requires output byte-size to be multiple of f32 size",
+                ));
+            }
 
-        let pattern = value.to_ne_bytes();
-        for chunk in out.chunks_exact_mut(std::mem::size_of::<f32>()) {
-            chunk.copy_from_slice(&pattern);
-        }
-        Ok(())
-    })?;
+            let pattern = value.to_ne_bytes();
+            for chunk in out.chunks_exact_mut(element_bytes) {
+                chunk.copy_from_slice(&pattern);
+            }
+            Ok(())
+        })?;
 
     Ok(())
 }

--- a/execution_cpu/src/kernel/cpu/read_at.rs
+++ b/execution_cpu/src/kernel/cpu/read_at.rs
@@ -63,14 +63,114 @@ pub fn launch(
         )));
     }
 
-    let b = pos * std::mem::size_of::<f32>();
+    let element_bytes = std::mem::size_of::<f32>();
+    let b = pos.checked_mul(element_bytes).ok_or_else(|| {
+        CpuKernelLaunchError::new(format!(
+            "cpu.read_at position {pos} overflows byte offset calculation"
+        ))
+    })?;
+    let e = b.checked_add(element_bytes).ok_or_else(|| {
+        CpuKernelLaunchError::new(format!(
+            "cpu.read_at position {pos} overflows byte range calculation"
+        ))
+    })?;
+
     let value_bytes = in_storage
         .buffer()
-        .with_read_bytes(|src| [src[b], src[b + 1], src[b + 2], src[b + 3]]);
+        .with_read_bytes(|src| {
+            let Some(slot) = src.get(b..e) else {
+                return Err(CpuKernelLaunchError::new(format!(
+                    "cpu.read_at position {pos} (byte range {b}..{e}) is out of bounds for input buffer of {} bytes",
+                    src.len()
+                )));
+            };
+            Ok([slot[0], slot[1], slot[2], slot[3]])
+        })?;
 
     out_storage.buffer().with_write_bytes(|dst| {
-        dst[0..4].copy_from_slice(&value_bytes);
-    });
+        let Some(out_slot) = dst.get_mut(0..element_bytes) else {
+            return Err(CpuKernelLaunchError::new(format!(
+                "cpu.read_at requires output buffer of at least {element_bytes} bytes, got {} bytes",
+                dst.len()
+            )));
+        };
+        out_slot.copy_from_slice(&value_bytes);
+        Ok(())
+    })?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use schema::{DType, KernelArg};
+
+    use super::{input_key, launch, output_key, pos_key};
+    use crate::{CpuBuffer, CpuKernelArgs, CpuKernelLaunchConfig, CpuStorage};
+
+    #[test]
+    fn launch_reads_value_at_position() {
+        let mut args = CpuKernelArgs::new();
+        let input = CpuStorage::new(
+            CpuBuffer::new_with_alignment(encode_f32_slice(&[1.0, 2.5, 3.0]), DType::F32.alignment())
+                .expect("aligned buffer creation should succeed"),
+            DType::F32,
+        )
+        .expect("typed storage creation should succeed");
+        let out = CpuStorage::new(
+            CpuBuffer::new_with_alignment(vec![0u8; 4], DType::F32.alignment())
+                .expect("aligned buffer creation should succeed"),
+            DType::F32,
+        )
+        .expect("typed storage creation should succeed");
+        args.insert(KernelArg::storage(input_key(), input))
+            .expect("in insertion should succeed");
+        args.insert(KernelArg::storage(output_key(), out.clone()))
+            .expect("out insertion should succeed");
+        args.insert(KernelArg::usize(pos_key(), 1))
+            .expect("pos insertion should succeed");
+
+        launch(&args, &CpuKernelLaunchConfig::new("cpu.read_at"))
+            .expect("read_at launch should succeed");
+
+        let value = out
+            .buffer()
+            .with_read_bytes(|bytes| f32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]));
+        assert_eq!(value, 2.5);
+    }
+
+    #[test]
+    fn launch_rejects_out_of_bounds_position() {
+        let mut args = CpuKernelArgs::new();
+        let input = CpuStorage::new(
+            CpuBuffer::new_with_alignment(vec![0u8; 8], DType::F32.alignment())
+                .expect("aligned buffer creation should succeed"),
+            DType::F32,
+        )
+        .expect("typed storage creation should succeed");
+        let out = CpuStorage::new(
+            CpuBuffer::new_with_alignment(vec![0u8; 4], DType::F32.alignment())
+                .expect("aligned buffer creation should succeed"),
+            DType::F32,
+        )
+        .expect("typed storage creation should succeed");
+        args.insert(KernelArg::storage(input_key(), input))
+            .expect("in insertion should succeed");
+        args.insert(KernelArg::storage(output_key(), out))
+            .expect("out insertion should succeed");
+        args.insert(KernelArg::usize(pos_key(), 2))
+            .expect("pos insertion should succeed");
+
+        let err = launch(&args, &CpuKernelLaunchConfig::new("cpu.read_at"))
+            .expect_err("read_at launch should fail for out-of-bounds position");
+        assert!(err.message().contains("out of bounds"));
+    }
+
+    fn encode_f32_slice(values: &[f32]) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(std::mem::size_of_val(values));
+        for value in values {
+            bytes.extend_from_slice(&value.to_ne_bytes());
+        }
+        bytes
+    }
 }

--- a/execution_cpu/src/kernel/cpu/read_at.rs
+++ b/execution_cpu/src/kernel/cpu/read_at.rs
@@ -112,8 +112,11 @@ mod tests {
     fn launch_reads_value_at_position() {
         let mut args = CpuKernelArgs::new();
         let input = CpuStorage::new(
-            CpuBuffer::new_with_alignment(encode_f32_slice(&[1.0, 2.5, 3.0]), DType::F32.alignment())
-                .expect("aligned buffer creation should succeed"),
+            CpuBuffer::new_with_alignment(
+                encode_f32_slice(&[1.0, 2.5, 3.0]),
+                DType::F32.alignment(),
+            )
+            .expect("aligned buffer creation should succeed"),
             DType::F32,
         )
         .expect("typed storage creation should succeed");

--- a/execution_cpu/src/kernel/cpu/read_at.rs
+++ b/execution_cpu/src/kernel/cpu/read_at.rs
@@ -22,19 +22,25 @@ pub fn launch(
     let out_key = output_key();
     let pos_key = pos_key();
 
-    let in_storage = args.args().require_as::<StorageValue>(&in_key).map_err(|err| {
-        CpuKernelLaunchError::new(format!(
-            "cpu.read_at requires input storage arg '{}': {err:?}",
-            in_key.tag().as_str()
-        ))
-    })?;
+    let in_storage = args
+        .args()
+        .require_as::<StorageValue>(&in_key)
+        .map_err(|err| {
+            CpuKernelLaunchError::new(format!(
+                "cpu.read_at requires input storage arg '{}': {err:?}",
+                in_key.tag().as_str()
+            ))
+        })?;
 
-    let out_storage = args.args().require_as::<StorageValue>(&out_key).map_err(|err| {
-        CpuKernelLaunchError::new(format!(
-            "cpu.read_at requires output storage arg '{}': {err:?}",
-            out_key.tag().as_str()
-        ))
-    })?;
+    let out_storage = args
+        .args()
+        .require_as::<StorageValue>(&out_key)
+        .map_err(|err| {
+            CpuKernelLaunchError::new(format!(
+                "cpu.read_at requires output storage arg '{}': {err:?}",
+                out_key.tag().as_str()
+            ))
+        })?;
 
     let pos = *args.args().require_as::<usize>(&pos_key).map_err(|err| {
         CpuKernelLaunchError::new(format!(
@@ -58,9 +64,9 @@ pub fn launch(
     }
 
     let b = pos * std::mem::size_of::<f32>();
-    let value_bytes = in_storage.buffer().with_read_bytes(|src| {
-        [src[b], src[b + 1], src[b + 2], src[b + 3]]
-    });
+    let value_bytes = in_storage
+        .buffer()
+        .with_read_bytes(|src| [src[b], src[b + 1], src[b + 2], src[b + 3]]);
 
     out_storage.buffer().with_write_bytes(|dst| {
         dst[0..4].copy_from_slice(&value_bytes);

--- a/execution_cpu/src/kernel/cpu/write_at.rs
+++ b/execution_cpu/src/kernel/cpu/write_at.rs
@@ -22,12 +22,15 @@ pub fn launch(
     let pos_key = pos_key();
     let value_key = value_key();
 
-    let out_storage = args.args().require_as::<StorageValue>(&out_key).map_err(|err| {
-        CpuKernelLaunchError::new(format!(
-            "cpu.write_at requires output storage arg '{}': {err:?}",
-            out_key.tag().as_str()
-        ))
-    })?;
+    let out_storage = args
+        .args()
+        .require_as::<StorageValue>(&out_key)
+        .map_err(|err| {
+            CpuKernelLaunchError::new(format!(
+                "cpu.write_at requires output storage arg '{}': {err:?}",
+                out_key.tag().as_str()
+            ))
+        })?;
 
     let pos = *args.args().require_as::<usize>(&pos_key).map_err(|err| {
         CpuKernelLaunchError::new(format!(

--- a/execution_cpu/src/kernel/cpu/write_at.rs
+++ b/execution_cpu/src/kernel/cpu/write_at.rs
@@ -53,11 +53,91 @@ pub fn launch(
         )));
     }
 
-    let b = pos * std::mem::size_of::<f32>();
+    let element_bytes = std::mem::size_of::<f32>();
+    let b = pos.checked_mul(element_bytes).ok_or_else(|| {
+        CpuKernelLaunchError::new(format!(
+            "cpu.write_at position {pos} overflows byte offset calculation"
+        ))
+    })?;
+    let e = b.checked_add(element_bytes).ok_or_else(|| {
+        CpuKernelLaunchError::new(format!(
+            "cpu.write_at position {pos} overflows byte range calculation"
+        ))
+    })?;
+
     let encoded = value.to_ne_bytes();
     out_storage.buffer().with_write_bytes(|dst| {
-        dst[b..b + 4].copy_from_slice(&encoded);
-    });
+        let Some(slot) = dst.get_mut(b..e) else {
+            return Err(CpuKernelLaunchError::new(format!(
+                "cpu.write_at position {pos} (byte range {b}..{e}) is out of bounds for output buffer of {} bytes",
+                dst.len()
+            )));
+        };
+        slot.copy_from_slice(&encoded);
+        Ok(())
+    })?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use schema::{DType, KernelArg};
+
+    use super::{launch, output_key, pos_key, value_key};
+    use crate::{CpuBuffer, CpuKernelArgs, CpuKernelLaunchConfig, CpuStorage};
+
+    #[test]
+    fn launch_writes_value_at_position() {
+        let mut args = CpuKernelArgs::new();
+        let out = CpuStorage::new(
+            CpuBuffer::new_with_alignment(vec![0u8; 16], DType::F32.alignment())
+                .expect("aligned buffer creation should succeed"),
+            DType::F32,
+        )
+        .expect("typed storage creation should succeed");
+        args.insert(KernelArg::storage(output_key(), out.clone()))
+            .expect("out insertion should succeed");
+        args.insert(KernelArg::usize(pos_key(), 2))
+            .expect("pos insertion should succeed");
+        args.insert(KernelArg::f32(value_key(), 7.5))
+            .expect("value insertion should succeed");
+
+        launch(&args, &CpuKernelLaunchConfig::new("cpu.write_at"))
+            .expect("write_at launch should succeed");
+
+        let values = out.buffer().with_read_bytes(decode_f32_vec);
+        assert_eq!(values, vec![0.0, 0.0, 7.5, 0.0]);
+    }
+
+    #[test]
+    fn launch_rejects_out_of_bounds_position() {
+        let mut args = CpuKernelArgs::new();
+        let out = CpuStorage::new(
+            CpuBuffer::new_with_alignment(vec![0u8; 8], DType::F32.alignment())
+                .expect("aligned buffer creation should succeed"),
+            DType::F32,
+        )
+        .expect("typed storage creation should succeed");
+        args.insert(KernelArg::storage(output_key(), out))
+            .expect("out insertion should succeed");
+        args.insert(KernelArg::usize(pos_key(), 2))
+            .expect("pos insertion should succeed");
+        args.insert(KernelArg::f32(value_key(), 1.25))
+            .expect("value insertion should succeed");
+
+        let err = launch(&args, &CpuKernelLaunchConfig::new("cpu.write_at"))
+            .expect_err("write_at launch should fail for out-of-bounds position");
+        assert!(err.message().contains("out of bounds"));
+    }
+
+    fn decode_f32_vec(bytes: &[u8]) -> Vec<f32> {
+        let mut chunks = bytes.chunks_exact(std::mem::size_of::<f32>());
+        let values: Vec<f32> = chunks
+            .by_ref()
+            .map(|chunk| f32::from_ne_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+            .collect();
+        assert!(chunks.remainder().is_empty());
+        values
+    }
 }

--- a/execution_cpu/src/kernel/types.rs
+++ b/execution_cpu/src/kernel/types.rs
@@ -65,6 +65,10 @@ impl CpuKernelArgs {
     pub fn len(&self) -> usize {
         self.args.len()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.args.len() == 0
+    }
 }
 
 impl Default for CpuKernelArgs {

--- a/execution_cpu/src/storage.rs
+++ b/execution_cpu/src/storage.rs
@@ -26,8 +26,12 @@ impl CpuRawBuffer {
             return Err(CpuStorageAllocError::InvalidAlignment { alignment });
         }
 
-        let layout = Layout::from_size_align(len, alignment)
-            .map_err(|_| CpuStorageAllocError::LayoutError { bytes: len, alignment })?;
+        let layout = Layout::from_size_align(len, alignment).map_err(|_| {
+            CpuStorageAllocError::LayoutError {
+                bytes: len,
+                alignment,
+            }
+        })?;
 
         if len == 0 {
             return Ok(Self {
@@ -136,32 +140,50 @@ impl CpuBuffer {
     }
 
     pub fn len_bytes(&self) -> usize {
-        let data = self.data.read().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let data = self
+            .data
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         data.len
     }
 
     pub fn alignment(&self) -> usize {
-        let data = self.data.read().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let data = self
+            .data
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         data.alignment
     }
 
     pub fn with_read_bytes<R>(&self, f: impl FnOnce(&[u8]) -> R) -> R {
-        let data = self.data.read().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let data = self
+            .data
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         f(data.as_slice())
     }
 
     pub fn with_write_bytes<R>(&self, f: impl FnOnce(&mut [u8]) -> R) -> R {
-        let mut data = self.data.write().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut data = self
+            .data
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         f(data.as_mut_slice())
     }
 
     pub fn with_read_ptr<R>(&self, f: impl FnOnce(*const u8, usize) -> R) -> R {
-        let data = self.data.read().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let data = self
+            .data
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         f(data.ptr.as_ptr(), data.len)
     }
 
     pub fn with_write_ptr<R>(&self, f: impl FnOnce(*mut u8, usize) -> R) -> R {
-        let data = self.data.write().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let data = self
+            .data
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         f(data.ptr.as_ptr(), data.len)
     }
 }
@@ -186,7 +208,7 @@ impl CpuStorage {
         dtype: DType,
     ) -> Result<Self, CpuStorageAllocError> {
         let dtype_size = dtype.size_bytes();
-        if bytes % dtype_size != 0 {
+        if !bytes.is_multiple_of(dtype_size) {
             return Err(CpuStorageAllocError::InvalidByteSizeForDType {
                 bytes,
                 dtype,

--- a/execution_cpu/src/storage_context.rs
+++ b/execution_cpu/src/storage_context.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct CpuStorageContext {
     numa_node: usize,
 }
@@ -15,12 +15,6 @@ impl CpuStorageContext {
 
     pub fn numa_node(&self) -> usize {
         self.numa_node
-    }
-}
-
-impl Default for CpuStorageContext {
-    fn default() -> Self {
-        Self { numa_node: 0 }
     }
 }
 

--- a/runtime/src/registry.rs
+++ b/runtime/src/registry.rs
@@ -66,7 +66,11 @@ impl KernelRegistry {
     }
 
     pub fn select(&mut self, key: &KernelKey) -> Option<KernelLauncher> {
-        if let Some(launcher) = self.cache.as_mut().and_then(|cache| cache.get(key).cloned()) {
+        if let Some(launcher) = self
+            .cache
+            .as_mut()
+            .and_then(|cache| cache.get(key).cloned())
+        {
             self.stats.cache_hits += 1;
             return Some(launcher);
         }


### PR DESCRIPTION
## Overview
This PR introduces a CI workflow and improves several core operations across the project.  
The main goal is to establish automated quality checks while refining dense tensor operations and CPU execution behavior.

## Key Changes

### CI / Tooling
- Add GitHub Actions workflow (`ci.yml`)
  - `cargo fmt --check`
  - `cargo clippy -D warnings`
  - `cargo check`
  - `cargo test`
- Introduce local CI execution via `Makefile` (`make ci` using `act`)
- Update README with local CI instructions

### Dense Ops / Execution
- Improve `read_at` / `write_at` safety and clarity
- Add overflow and bounds-related validation paths
- Refactor error enums for better structure
- Minor execution CPU kernel refinements (`args.is_empty()` etc.)

### Tensor / Storage
- Optimize contiguous storage access in `read_all_f32` and `data`
- Reduce unnecessary index calculations when tensor is contiguous
- Minor formatting and import order cleanup across modules

### API Layer
- Reorder public exports for consistency
- Improve formatting and readability in `at`, `fill`, and `narrow`

## Motivation
- Establish a reproducible development pipeline.
- Catch formatting, lint, and logic issues automatically during PRs.
- Improve runtime safety and performance in dense tensor access paths.

## Notes
- No public API breaking changes intended.
- Most changes are internal refactors and CI setup.
- CI cache is disabled when running via `act` (`ACT=true`).