### PR TITLE
refactor: simplify condition checks for caching and tensor stride val…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache Cargo build artifacts
-        if: ${{ !env.ACT }}
+        if: ${{ env.ACT != 'true' }}
         uses: Swatinem/rust-cache@v2
 
       - name: Cargo fmt (check)

--- a/core/dense_impl/src/tensor.rs
+++ b/core/dense_impl/src/tensor.rs
@@ -60,14 +60,14 @@ impl DenseTensorImpl {
     /// True when the tensor occupies a contiguous, offset-0 region of its storage.
     /// The fill kernel requires this.
     pub fn is_packed(&self) -> bool {
-        self.offset == 0 && self.strides == contiguous_strides(&self.shape)
+        self.offset == 0 && has_contiguous_strides(&self.shape, &self.strides)
     }
 
     /// Read all elements in row-major order as `Vec<f32>`. Used by `impl Debug for Tensor`.
     pub fn read_all_f32(&self) -> Vec<f32> {
         let numel = self.numel();
         let mut result = Vec::with_capacity(numel);
-        let is_contiguous = self.strides == contiguous_strides(&self.shape);
+        let is_contiguous = has_contiguous_strides(&self.shape, &self.strides);
         match &self.storage {
             Storage::Cpu(storage) => {
                 storage.buffer().with_read_bytes(|bytes| {
@@ -113,6 +113,24 @@ pub(crate) fn flat_to_pos(flat: usize, shape: &[usize], strides: &[usize], offse
     pos
 }
 
+fn has_contiguous_strides(shape: &[usize], strides: &[usize]) -> bool {
+    if shape.len() != strides.len() {
+        return false;
+    }
+
+    let mut expected = 1usize;
+    for (&dim, &stride) in shape.iter().zip(strides).rev() {
+        if stride != expected {
+            return false;
+        }
+        expected = match expected.checked_mul(dim) {
+            Some(next) => next,
+            None => return false,
+        };
+    }
+    true
+}
+
 pub(crate) fn contiguous_strides(shape: &[usize]) -> Vec<usize> {
     let n = shape.len();
     if n == 0 {
@@ -130,7 +148,7 @@ impl DenseTensorImpl {
     pub fn data(&self) -> Vec<f32> {
         let numel = self.numel();
         let mut result = Vec::with_capacity(numel);
-        let is_contiguous = self.strides == contiguous_strides(&self.shape);
+        let is_contiguous = has_contiguous_strides(&self.shape, &self.strides);
         match &self.storage {
             Storage::Cpu(storage) => {
                 storage.buffer().with_read_bytes(|bytes| {

--- a/execution_cpu/src/kernel/types.rs
+++ b/execution_cpu/src/kernel/types.rs
@@ -67,7 +67,7 @@ impl CpuKernelArgs {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.args.len() == 0
+        self.args.is_empty()
     }
 }
 


### PR DESCRIPTION
## Summary
This PR refactors several small logic paths to improve clarity, safety, and consistency across CI and tensor utilities.

### Changes
- **CI**
  - Simplified cache condition in `.github/workflows/ci.yml`
  - Use explicit comparison `env.ACT != 'true'` to avoid ambiguous truthiness

- **Dense Tensor**
  - Introduced `has_contiguous_strides(shape, strides)` helper
  - Replaced repeated `strides == contiguous_strides(shape)` checks
  - Avoids unnecessary allocation of temporary stride vectors
  - Improves readability and reduces overhead in:
    - `is_packed`
    - `read_all_f32`
    - `data`

- **CPU Execution**
  - Replaced `len() == 0` with `is_empty()` for idiomatic Rust

### Motivation
The previous implementation recomputed contiguous strides using allocation-heavy comparisons.  
This change introduces a lightweight stride validation function that:

- removes allocation costs
- improves intent clarity
- centralizes contiguous stride logic

### Notes
- Behavior is unchanged; this is a refactor only.
- Verified that branches are auto-mergeable.

### Checklist
- [x] Refactor only (no functional change intended)
- [x] CI updated
- [x] Code compiles locally