### PR TITLE
Refactor/ops

### DIFF
--- a/core/dense_impl/src/ops/at.rs
+++ b/core/dense_impl/src/ops/at.rs
@@ -7,9 +7,7 @@ use runtime::{
     DispatchApi, DispatchError, Dispatcher, KernelRegistryConfig, KeyVersion, OpTag, SeedSpec,
     V1KeyParts,
 };
-use schema::{
-    ArgKey, ArgKind, ArgRole, DType, KernelArg, Scalar, ScalarBuffer, ViewSpecError,
-};
+use schema::{ArgKey, ArgKind, ArgRole, DType, KernelArg, Scalar, ScalarBuffer, ViewSpecError};
 
 use crate::DenseTensorImpl;
 

--- a/core/dense_impl/src/ops/at.rs
+++ b/core/dense_impl/src/ops/at.rs
@@ -7,14 +7,17 @@ use runtime::{
     DispatchApi, DispatchError, Dispatcher, KernelRegistryConfig, KeyVersion, OpTag, SeedSpec,
     V1KeyParts,
 };
-use schema::{ArgKey, ArgKind, ArgRole, DType, KernelArg, Scalar};
+use schema::{
+    ArgKey, ArgKind, ArgRole, DType, KernelArg, Scalar, ScalarBuffer, ViewSpecError,
+};
 
 use crate::DenseTensorImpl;
 
 /// Read a single element at the given multi-dimensional index.
 pub fn exec_read(tensor: &DenseTensorImpl, indices: &[usize]) -> Result<Scalar, DenseAtError> {
-    let pos = validated_pos(tensor, indices)?;
     let dtype = tensor.dtype();
+    let view_spec = tensor.view_spec().map_err(DenseAtError::InvalidViewSpec)?;
+    let encoded_indices = encode_indices(indices)?;
 
     let context = StorageContext::from_execution_tag(tensor.execution_tag());
     let out = Storage::allocate(
@@ -36,7 +39,10 @@ pub fn exec_read(tensor: &DenseTensorImpl, indices: &[usize]) -> Result<Scalar, 
         .insert(KernelArg::storage(read_output_key(), out_cpu.clone()))
         .map_err(DenseAtError::KernelArgs)?;
     cpu_args
-        .insert(KernelArg::usize(pos_key(), pos))
+        .insert(KernelArg::view_spec(view_spec_key(), view_spec))
+        .map_err(DenseAtError::KernelArgs)?;
+    cpu_args
+        .insert(KernelArg::scalar_buffer(indices_key(), encoded_indices))
         .map_err(DenseAtError::KernelArgs)?;
     let args = KernelArgs::Cpu(cpu_args);
 
@@ -68,8 +74,9 @@ pub fn exec_write(
     indices: &[usize],
     value: Scalar,
 ) -> Result<(), DenseAtError> {
-    let pos = validated_pos(tensor, indices)?;
     let dtype = tensor.dtype();
+    let view_spec = tensor.view_spec().map_err(DenseAtError::InvalidViewSpec)?;
+    let encoded_indices = encode_indices(indices)?;
 
     let out_cpu = match tensor.storage() {
         Storage::Cpu(storage) => storage.clone(),
@@ -80,7 +87,10 @@ pub fn exec_write(
         .insert(KernelArg::storage(write_output_key(), out_cpu))
         .map_err(DenseAtError::KernelArgs)?;
     cpu_args
-        .insert(KernelArg::usize(pos_key(), pos))
+        .insert(KernelArg::view_spec(view_spec_key(), view_spec))
+        .map_err(DenseAtError::KernelArgs)?;
+    cpu_args
+        .insert(KernelArg::scalar_buffer(indices_key(), encoded_indices))
         .map_err(DenseAtError::KernelArgs)?;
     insert_write_value_arg(&mut cpu_args, dtype, value)?;
     let args = KernelArgs::Cpu(cpu_args);
@@ -104,19 +114,9 @@ pub fn exec_write(
 
 #[derive(Debug)]
 pub enum DenseAtError {
-    RankMismatch {
-        expected: usize,
-        actual: usize,
-    },
-    IndexOutOfBounds {
-        dim: usize,
-        index: usize,
-        size: usize,
-    },
-    ScalarDTypeMismatch {
-        tensor_dtype: DType,
-        value: Scalar,
-    },
+    ScalarDTypeMismatch { tensor_dtype: DType, value: Scalar },
+    InvalidViewSpec(ViewSpecError),
+    IndicesEncodingOverflow,
     StorageAlloc(StorageAllocError),
     KernelArgs(schema::KernelArgsError),
     DispatcherPoisoned,
@@ -135,38 +135,16 @@ fn write_output_key() -> ArgKey {
     ArgKey::new(ArgRole::Output, "out", ArgKind::Storage)
 }
 
-fn pos_key() -> ArgKey {
-    ArgKey::new(ArgRole::Param, "pos", ArgKind::Usize)
+fn view_spec_key() -> ArgKey {
+    ArgKey::new(ArgRole::Param, "view_spec", ArgKind::ViewSpec)
+}
+
+fn indices_key() -> ArgKey {
+    ArgKey::new(ArgRole::Param, "indices", ArgKind::ScalarBuffer)
 }
 
 fn write_value_key(dtype: DType) -> ArgKey {
     ArgKey::new(ArgRole::Param, "value", dtype.value_arg_kind())
-}
-
-fn validated_pos(tensor: &DenseTensorImpl, indices: &[usize]) -> Result<usize, DenseAtError> {
-    let shape = tensor.shape();
-    if indices.len() != shape.len() {
-        return Err(DenseAtError::RankMismatch {
-            expected: shape.len(),
-            actual: indices.len(),
-        });
-    }
-    for (dim, (&idx, &size)) in indices.iter().zip(shape.iter()).enumerate() {
-        if idx >= size {
-            return Err(DenseAtError::IndexOutOfBounds {
-                dim,
-                index: idx,
-                size,
-            });
-        }
-    }
-    let pos = tensor.offset()
-        + indices
-            .iter()
-            .zip(tensor.strides().iter())
-            .map(|(i, s)| i * s)
-            .sum::<usize>();
-    Ok(pos)
 }
 
 fn scalar_from_element_bytes(dtype: DType, bytes: &[u8]) -> Scalar {
@@ -191,6 +169,20 @@ fn insert_write_value_arg(
         .args_mut()
         .insert_scalar(write_value_key(dtype), value)
         .map_err(DenseAtError::KernelArgs)
+}
+
+fn encode_indices(indices: &[usize]) -> Result<ScalarBuffer, DenseAtError> {
+    let mut bytes = Vec::with_capacity(
+        indices
+            .len()
+            .checked_mul(std::mem::size_of::<i64>())
+            .ok_or(DenseAtError::IndicesEncodingOverflow)?,
+    );
+    for &index in indices {
+        let index = i64::try_from(index).map_err(|_| DenseAtError::IndicesEncodingOverflow)?;
+        bytes.extend_from_slice(&index.to_ne_bytes());
+    }
+    ScalarBuffer::new(DType::I64, indices.len(), bytes).ok_or(DenseAtError::IndicesEncodingOverflow)
 }
 
 fn dense_dispatcher() -> &'static Mutex<Dispatcher> {

--- a/core/dense_impl/src/ops/fill.rs
+++ b/core/dense_impl/src/ops/fill.rs
@@ -104,7 +104,9 @@ fn insert_fill_view_args(
     cpu_args: &mut CpuKernelArgs,
     tensor: &DenseTensorImpl,
 ) -> Result<(), DenseFillError> {
-    let view_spec = tensor.view_spec().map_err(DenseFillError::InvalidViewSpec)?;
+    let view_spec = tensor
+        .view_spec()
+        .map_err(DenseFillError::InvalidViewSpec)?;
     cpu_args
         .insert(KernelArg::view_spec(view_spec_key(), view_spec))
         .map_err(DenseFillError::KernelArgs)?;

--- a/core/dense_impl/src/ops/fill.rs
+++ b/core/dense_impl/src/ops/fill.rs
@@ -5,7 +5,7 @@ use runtime::{
     DispatchApi, DispatchError, Dispatcher, KernelRegistryConfig, KeyVersion, OpTag, SeedSpec,
     V1KeyParts,
 };
-use schema::{ArgKey, ArgKind, ArgRole, DType, KernelArg, Scalar, ScalarBuffer};
+use schema::{ArgKey, ArgKind, ArgRole, DType, KernelArg, Scalar, ViewSpec, ViewSpecError};
 
 use crate::DenseTensorImpl;
 
@@ -23,9 +23,7 @@ fn dispatch_fill_kernel(tensor: &DenseTensorImpl, value: Scalar) -> Result<(), D
         .insert(KernelArg::storage(output_key(), out))
         .map_err(DenseFillError::KernelArgs)?;
     insert_fill_value_arg(&mut cpu_args, dtype, value)?;
-    if !tensor.is_packed() {
-        insert_fill_view_args(&mut cpu_args, tensor)?;
-    }
+    insert_fill_view_args(&mut cpu_args, tensor)?;
     let args = KernelArgs::Cpu(cpu_args);
 
     let seed = SeedSpec::V1(V1KeyParts {
@@ -47,21 +45,8 @@ fn dispatch_fill_kernel(tensor: &DenseTensorImpl, value: Scalar) -> Result<(), D
 
 #[derive(Debug)]
 pub enum DenseFillError {
-    ScalarDTypeMismatch {
-        tensor_dtype: DType,
-        value: Scalar,
-    },
-    PositionOverflow {
-        pos: usize,
-        element_bytes: usize,
-    },
-    ViewOutOfBounds {
-        pos: usize,
-        range_start: usize,
-        range_end: usize,
-        buffer_len: usize,
-    },
-    ViewMetadataOverflow,
+    ScalarDTypeMismatch { tensor_dtype: DType, value: Scalar },
+    InvalidViewSpec(ViewSpecError),
     DispatcherPoisoned,
     KernelArgs(schema::KernelArgsError),
     Dispatch(DispatchError),
@@ -75,16 +60,8 @@ fn value_key(dtype: DType) -> ArgKey {
     ArgKey::new(ArgRole::Param, "value", dtype.value_arg_kind())
 }
 
-fn view_shape_key() -> ArgKey {
-    ArgKey::new(ArgRole::Param, "view_shape", ArgKind::ScalarBuffer)
-}
-
-fn view_strides_key() -> ArgKey {
-    ArgKey::new(ArgRole::Param, "view_strides", ArgKind::ScalarBuffer)
-}
-
-fn view_offset_key() -> ArgKey {
-    ArgKey::new(ArgRole::Param, "view_offset", ArgKind::Usize)
+fn view_spec_key() -> ArgKey {
+    ArgKey::new(ArgRole::Param, "view_spec", ArgKind::ViewSpec)
 }
 
 fn dense_dispatcher() -> &'static Mutex<Dispatcher> {
@@ -128,33 +105,15 @@ fn insert_fill_view_args(
     tensor: &DenseTensorImpl,
 ) -> Result<(), DenseFillError> {
     cpu_args
-        .insert(KernelArg::scalar_buffer(
-            view_shape_key(),
-            usize_slice_to_i64_scalar_buffer(tensor.shape())?,
+        .insert(KernelArg::view_spec(
+            view_spec_key(),
+            ViewSpec::new(
+                tensor.shape().to_vec(),
+                tensor.strides().to_vec(),
+                tensor.offset(),
+            )
+            .map_err(DenseFillError::InvalidViewSpec)?,
         ))
-        .map_err(DenseFillError::KernelArgs)?;
-    cpu_args
-        .insert(KernelArg::scalar_buffer(
-            view_strides_key(),
-            usize_slice_to_i64_scalar_buffer(tensor.strides())?,
-        ))
-        .map_err(DenseFillError::KernelArgs)?;
-    cpu_args
-        .insert(KernelArg::usize(view_offset_key(), tensor.offset()))
         .map_err(DenseFillError::KernelArgs)?;
     Ok(())
-}
-
-fn usize_slice_to_i64_scalar_buffer(values: &[usize]) -> Result<ScalarBuffer, DenseFillError> {
-    let mut bytes = Vec::with_capacity(
-        values
-            .len()
-            .checked_mul(std::mem::size_of::<i64>())
-            .ok_or(DenseFillError::ViewMetadataOverflow)?,
-    );
-    for &value in values {
-        let value = i64::try_from(value).map_err(|_| DenseFillError::ViewMetadataOverflow)?;
-        bytes.extend_from_slice(&value.to_ne_bytes());
-    }
-    ScalarBuffer::new(DType::I64, values.len(), bytes).ok_or(DenseFillError::ViewMetadataOverflow)
 }

--- a/core/dense_impl/src/ops/fill.rs
+++ b/core/dense_impl/src/ops/fill.rs
@@ -5,16 +5,12 @@ use runtime::{
     DispatchApi, DispatchError, Dispatcher, KernelRegistryConfig, KeyVersion, OpTag, SeedSpec,
     V1KeyParts,
 };
-use schema::{ArgKey, ArgKind, ArgRole, DType, EncodedScalar, KernelArg, Scalar};
+use schema::{ArgKey, ArgKind, ArgRole, DType, KernelArg, Scalar, ScalarBuffer};
 
-use crate::{DenseTensorImpl, tensor::flat_to_pos};
+use crate::DenseTensorImpl;
 
 pub fn exec(tensor: &mut DenseTensorImpl, value: Scalar) -> Result<(), DenseFillError> {
-    if tensor.is_packed() {
-        return dispatch_fill_kernel(tensor, value);
-    }
-
-    fill_view_cpu(tensor, value)
+    dispatch_fill_kernel(tensor, value)
 }
 
 fn dispatch_fill_kernel(tensor: &DenseTensorImpl, value: Scalar) -> Result<(), DenseFillError> {
@@ -27,6 +23,9 @@ fn dispatch_fill_kernel(tensor: &DenseTensorImpl, value: Scalar) -> Result<(), D
         .insert(KernelArg::storage(output_key(), out))
         .map_err(DenseFillError::KernelArgs)?;
     insert_fill_value_arg(&mut cpu_args, dtype, value)?;
+    if !tensor.is_packed() {
+        insert_fill_view_args(&mut cpu_args, tensor)?;
+    }
     let args = KernelArgs::Cpu(cpu_args);
 
     let seed = SeedSpec::V1(V1KeyParts {
@@ -46,42 +45,6 @@ fn dispatch_fill_kernel(tensor: &DenseTensorImpl, value: Scalar) -> Result<(), D
     Ok(())
 }
 
-fn fill_view_cpu(tensor: &DenseTensorImpl, value: Scalar) -> Result<(), DenseFillError> {
-    let dtype = tensor.dtype();
-    let pattern = scalar_pattern(dtype, value)?;
-    let element_bytes = dtype.size_bytes();
-    let numel = tensor.numel();
-    let shape = tensor.shape();
-    let strides = tensor.strides();
-    let offset = tensor.offset();
-
-    let out = match tensor.storage() {
-        Storage::Cpu(storage) => storage.clone(),
-    };
-
-    out.buffer().with_write_bytes(|dst| {
-        for flat in 0..numel {
-            let pos = flat_to_pos(flat, shape, strides, offset);
-            let b = pos
-                .checked_mul(element_bytes)
-                .ok_or(DenseFillError::PositionOverflow { pos, element_bytes })?;
-            let e = b
-                .checked_add(element_bytes)
-                .ok_or(DenseFillError::PositionOverflow { pos, element_bytes })?;
-            let Some(slot) = dst.get_mut(b..e) else {
-                return Err(DenseFillError::ViewOutOfBounds {
-                    pos,
-                    range_start: b,
-                    range_end: e,
-                    buffer_len: dst.len(),
-                });
-            };
-            slot.copy_from_slice(pattern.as_slice());
-        }
-        Ok(())
-    })
-}
-
 #[derive(Debug)]
 pub enum DenseFillError {
     ScalarDTypeMismatch {
@@ -98,6 +61,7 @@ pub enum DenseFillError {
         range_end: usize,
         buffer_len: usize,
     },
+    ViewMetadataOverflow,
     DispatcherPoisoned,
     KernelArgs(schema::KernelArgsError),
     Dispatch(DispatchError),
@@ -109,6 +73,18 @@ fn output_key() -> ArgKey {
 
 fn value_key(dtype: DType) -> ArgKey {
     ArgKey::new(ArgRole::Param, "value", dtype.value_arg_kind())
+}
+
+fn view_shape_key() -> ArgKey {
+    ArgKey::new(ArgRole::Param, "view_shape", ArgKind::ScalarBuffer)
+}
+
+fn view_strides_key() -> ArgKey {
+    ArgKey::new(ArgRole::Param, "view_strides", ArgKind::ScalarBuffer)
+}
+
+fn view_offset_key() -> ArgKey {
+    ArgKey::new(ArgRole::Param, "view_offset", ArgKind::Usize)
 }
 
 fn dense_dispatcher() -> &'static Mutex<Dispatcher> {
@@ -147,13 +123,38 @@ fn insert_fill_value_arg(
         .map_err(DenseFillError::KernelArgs)
 }
 
-fn scalar_pattern(dtype: DType, value: Scalar) -> Result<EncodedScalar, DenseFillError> {
-    if let Some(encoded) = dtype.encode_scalar(&value) {
-        Ok(encoded)
-    } else {
-        Err(DenseFillError::ScalarDTypeMismatch {
-            tensor_dtype: dtype,
-            value,
-        })
+fn insert_fill_view_args(
+    cpu_args: &mut CpuKernelArgs,
+    tensor: &DenseTensorImpl,
+) -> Result<(), DenseFillError> {
+    cpu_args
+        .insert(KernelArg::scalar_buffer(
+            view_shape_key(),
+            usize_slice_to_i64_scalar_buffer(tensor.shape())?,
+        ))
+        .map_err(DenseFillError::KernelArgs)?;
+    cpu_args
+        .insert(KernelArg::scalar_buffer(
+            view_strides_key(),
+            usize_slice_to_i64_scalar_buffer(tensor.strides())?,
+        ))
+        .map_err(DenseFillError::KernelArgs)?;
+    cpu_args
+        .insert(KernelArg::usize(view_offset_key(), tensor.offset()))
+        .map_err(DenseFillError::KernelArgs)?;
+    Ok(())
+}
+
+fn usize_slice_to_i64_scalar_buffer(values: &[usize]) -> Result<ScalarBuffer, DenseFillError> {
+    let mut bytes = Vec::with_capacity(
+        values
+            .len()
+            .checked_mul(std::mem::size_of::<i64>())
+            .ok_or(DenseFillError::ViewMetadataOverflow)?,
+    );
+    for &value in values {
+        let value = i64::try_from(value).map_err(|_| DenseFillError::ViewMetadataOverflow)?;
+        bytes.extend_from_slice(&value.to_ne_bytes());
     }
+    ScalarBuffer::new(DType::I64, values.len(), bytes).ok_or(DenseFillError::ViewMetadataOverflow)
 }

--- a/core/dense_impl/src/ops/fill.rs
+++ b/core/dense_impl/src/ops/fill.rs
@@ -5,7 +5,7 @@ use runtime::{
     DispatchApi, DispatchError, Dispatcher, KernelRegistryConfig, KeyVersion, OpTag, SeedSpec,
     V1KeyParts,
 };
-use schema::{ArgKey, ArgKind, ArgRole, DType, KernelArg, Scalar, ViewSpec, ViewSpecError};
+use schema::{ArgKey, ArgKind, ArgRole, DType, KernelArg, Scalar, ViewSpecError};
 
 use crate::DenseTensorImpl;
 
@@ -104,16 +104,9 @@ fn insert_fill_view_args(
     cpu_args: &mut CpuKernelArgs,
     tensor: &DenseTensorImpl,
 ) -> Result<(), DenseFillError> {
+    let view_spec = tensor.view_spec().map_err(DenseFillError::InvalidViewSpec)?;
     cpu_args
-        .insert(KernelArg::view_spec(
-            view_spec_key(),
-            ViewSpec::new(
-                tensor.shape().to_vec(),
-                tensor.strides().to_vec(),
-                tensor.offset(),
-            )
-            .map_err(DenseFillError::InvalidViewSpec)?,
-        ))
+        .insert(KernelArg::view_spec(view_spec_key(), view_spec))
         .map_err(DenseFillError::KernelArgs)?;
     Ok(())
 }

--- a/core/dense_impl/src/tensor.rs
+++ b/core/dense_impl/src/tensor.rs
@@ -63,7 +63,6 @@ impl DenseTensorImpl {
     }
 
     /// True when the tensor occupies a contiguous, offset-0 region of its storage.
-    /// The fill kernel requires this.
     pub fn is_packed(&self) -> bool {
         self.offset == 0 && has_contiguous_strides(&self.shape, &self.strides)
     }

--- a/core/dense_impl/src/tensor.rs
+++ b/core/dense_impl/src/tensor.rs
@@ -1,5 +1,5 @@
 use execution::{ExecutionTag, Storage};
-use schema::{DType, Scalar};
+use schema::{DType, Scalar, ViewSpec, ViewSpecError};
 
 #[derive(Clone)]
 pub struct DenseTensorImpl {
@@ -44,6 +44,10 @@ impl DenseTensorImpl {
 
     pub fn offset(&self) -> usize {
         self.offset
+    }
+
+    pub fn view_spec(&self) -> Result<ViewSpec, ViewSpecError> {
+        ViewSpec::new(self.shape.clone(), self.strides.clone(), self.offset)
     }
 
     pub fn storage(&self) -> &Storage {

--- a/execution_cpu/src/kernel/cpu/fill.rs
+++ b/execution_cpu/src/kernel/cpu/fill.rs
@@ -181,20 +181,15 @@ fn decode_usize_buffer(
     buffer: &ScalarBuffer,
     arg_tag: &str,
 ) -> Result<Vec<usize>, CpuKernelLaunchError> {
-    if buffer.dtype() != DType::I64 {
-        return Err(CpuKernelLaunchError::new(format!(
-            "cpu.fill requires scalar-buffer arg '{}' to use i64 dtype, got {:?}",
-            arg_tag,
-            buffer.dtype()
-        )));
-    }
+    let raw = buffer.try_to_vec::<i64>().map_err(|err| {
+        CpuKernelLaunchError::new(format!(
+            "cpu.fill requires scalar-buffer arg '{}' to decode as i64 values: {err:?}",
+            arg_tag
+        ))
+    })?;
 
-    let mut chunks = buffer.bytes().chunks_exact(std::mem::size_of::<i64>());
-    let mut values = Vec::with_capacity(buffer.len());
-    for chunk in chunks.by_ref() {
-        let value = i64::from_ne_bytes([
-            chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7],
-        ]);
+    let mut values = Vec::with_capacity(raw.len());
+    for value in raw {
         if value < 0 {
             return Err(CpuKernelLaunchError::new(format!(
                 "cpu.fill requires scalar-buffer arg '{}' to contain non-negative i64 values",
@@ -207,12 +202,6 @@ fn decode_usize_buffer(
                 arg_tag
             ))
         })?);
-    }
-    if !chunks.remainder().is_empty() {
-        return Err(CpuKernelLaunchError::new(format!(
-            "cpu.fill scalar-buffer arg '{}' has invalid byte length",
-            arg_tag
-        )));
     }
 
     Ok(values)

--- a/execution_cpu/src/kernel/cpu/fill.rs
+++ b/execution_cpu/src/kernel/cpu/fill.rs
@@ -1,5 +1,5 @@
 use crate::{CpuKernelArgs, CpuKernelLaunchConfig, CpuKernelLaunchError};
-use schema::{ArgKey, ArgKind, ArgRole, DType, StorageValue};
+use schema::{ArgKey, ArgKind, ArgRole, DType, ScalarBuffer, StorageValue};
 
 pub fn output_key() -> ArgKey {
     ArgKey::new(ArgRole::Output, "out", ArgKind::Storage)
@@ -7,6 +7,18 @@ pub fn output_key() -> ArgKey {
 
 fn value_key(dtype: DType) -> ArgKey {
     ArgKey::new(ArgRole::Param, "value", dtype.value_arg_kind())
+}
+
+fn view_shape_key() -> ArgKey {
+    ArgKey::new(ArgRole::Param, "view_shape", ArgKind::ScalarBuffer)
+}
+
+fn view_strides_key() -> ArgKey {
+    ArgKey::new(ArgRole::Param, "view_strides", ArgKind::ScalarBuffer)
+}
+
+fn view_offset_key() -> ArgKey {
+    ArgKey::new(ArgRole::Param, "view_offset", ArgKind::Usize)
 }
 
 pub fn launch(
@@ -38,19 +50,44 @@ pub fn launch(
             ))
         })?;
     let element_bytes = dtype.size_bytes();
+    let view_spec = parse_view_spec(args)?;
     out_storage
         .buffer()
         .with_write_bytes(|out| -> Result<(), CpuKernelLaunchError> {
-            if out.len() % element_bytes != 0 {
-                return Err(CpuKernelLaunchError::new(
-                    format!(
-                        "cpu.fill requires output byte-size to be multiple of element size {element_bytes}"
-                    ),
-                ));
-            }
+            match &view_spec {
+                Some(spec) => {
+                    for flat in 0..spec.numel {
+                        let pos = flat_to_pos(flat, &spec.shape, &spec.strides, spec.offset)?;
+                        let b = pos.checked_mul(element_bytes).ok_or_else(|| {
+                            CpuKernelLaunchError::new(format!(
+                                "cpu.fill view position {pos} overflows byte offset calculation"
+                            ))
+                        })?;
+                        let e = b.checked_add(element_bytes).ok_or_else(|| {
+                            CpuKernelLaunchError::new(format!(
+                                "cpu.fill view position {pos} overflows byte range calculation"
+                            ))
+                        })?;
+                        let Some(slot) = out.get_mut(b..e) else {
+                            return Err(CpuKernelLaunchError::new(format!(
+                                "cpu.fill view position {pos} (byte range {b}..{e}) is out of bounds for output buffer of {} bytes",
+                                out.len()
+                            )));
+                        };
+                        slot.copy_from_slice(pattern.as_slice());
+                    }
+                }
+                None => {
+                    if out.len() % element_bytes != 0 {
+                        return Err(CpuKernelLaunchError::new(format!(
+                            "cpu.fill requires output byte-size to be multiple of element size {element_bytes}"
+                        )));
+                    }
 
-            for chunk in out.chunks_exact_mut(element_bytes) {
-                chunk.copy_from_slice(pattern.as_slice());
+                    for chunk in out.chunks_exact_mut(element_bytes) {
+                        chunk.copy_from_slice(pattern.as_slice());
+                    }
+                }
             }
             Ok(())
         })?;
@@ -58,9 +95,161 @@ pub fn launch(
     Ok(())
 }
 
+#[derive(Debug, Clone)]
+struct FillViewSpec {
+    shape: Vec<usize>,
+    strides: Vec<usize>,
+    offset: usize,
+    numel: usize,
+}
+
+fn parse_view_spec(args: &CpuKernelArgs) -> Result<Option<FillViewSpec>, CpuKernelLaunchError> {
+    let shape_key = view_shape_key();
+    let strides_key = view_strides_key();
+    let offset_key = view_offset_key();
+
+    let has_shape = args.args().iter().any(|arg| arg.key() == &shape_key);
+    let has_strides = args.args().iter().any(|arg| arg.key() == &strides_key);
+    let has_offset = args.args().iter().any(|arg| arg.key() == &offset_key);
+
+    if !(has_shape || has_strides || has_offset) {
+        return Ok(None);
+    }
+
+    if !(has_shape && has_strides && has_offset) {
+        return Err(CpuKernelLaunchError::new(
+            "cpu.fill view mode requires all view metadata args: view_shape, view_strides, view_offset",
+        ));
+    }
+
+    let shape = decode_usize_buffer(
+        args.args()
+            .require_scalar_buffer(&shape_key)
+            .map_err(|err| {
+                CpuKernelLaunchError::new(format!(
+                    "cpu.fill requires scalar-buffer param arg '{}': {err:?}",
+                    shape_key.tag().as_str()
+                ))
+            })?,
+        shape_key.tag().as_str(),
+    )?;
+    let strides = decode_usize_buffer(
+        args.args()
+            .require_scalar_buffer(&strides_key)
+            .map_err(|err| {
+                CpuKernelLaunchError::new(format!(
+                    "cpu.fill requires scalar-buffer param arg '{}': {err:?}",
+                    strides_key.tag().as_str()
+                ))
+            })?,
+        strides_key.tag().as_str(),
+    )?;
+    let offset = *args
+        .args()
+        .require_as::<usize>(&offset_key)
+        .map_err(|err| {
+            CpuKernelLaunchError::new(format!(
+                "cpu.fill requires usize param arg '{}': {err:?}",
+                offset_key.tag().as_str()
+            ))
+        })?;
+
+    if shape.len() != strides.len() {
+        return Err(CpuKernelLaunchError::new(format!(
+            "cpu.fill view metadata requires same rank for shape/strides, got shape={} and strides={}",
+            shape.len(),
+            strides.len()
+        )));
+    }
+
+    let numel = shape
+        .iter()
+        .try_fold(1usize, |acc, &dim| acc.checked_mul(dim).ok_or(()));
+    let numel = numel.map_err(|_| {
+        CpuKernelLaunchError::new("cpu.fill view shape overflows numel calculation")
+    })?;
+
+    Ok(Some(FillViewSpec {
+        shape,
+        strides,
+        offset,
+        numel,
+    }))
+}
+
+fn decode_usize_buffer(
+    buffer: &ScalarBuffer,
+    arg_tag: &str,
+) -> Result<Vec<usize>, CpuKernelLaunchError> {
+    if buffer.dtype() != DType::I64 {
+        return Err(CpuKernelLaunchError::new(format!(
+            "cpu.fill requires scalar-buffer arg '{}' to use i64 dtype, got {:?}",
+            arg_tag,
+            buffer.dtype()
+        )));
+    }
+
+    let mut chunks = buffer.bytes().chunks_exact(std::mem::size_of::<i64>());
+    let mut values = Vec::with_capacity(buffer.len());
+    for chunk in chunks.by_ref() {
+        let value = i64::from_ne_bytes([
+            chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7],
+        ]);
+        if value < 0 {
+            return Err(CpuKernelLaunchError::new(format!(
+                "cpu.fill requires scalar-buffer arg '{}' to contain non-negative i64 values",
+                arg_tag
+            )));
+        }
+        values.push(usize::try_from(value).map_err(|_| {
+            CpuKernelLaunchError::new(format!(
+                "cpu.fill scalar-buffer arg '{}' value {value} overflows usize",
+                arg_tag
+            ))
+        })?);
+    }
+    if !chunks.remainder().is_empty() {
+        return Err(CpuKernelLaunchError::new(format!(
+            "cpu.fill scalar-buffer arg '{}' has invalid byte length",
+            arg_tag
+        )));
+    }
+
+    Ok(values)
+}
+
+fn flat_to_pos(
+    flat: usize,
+    shape: &[usize],
+    strides: &[usize],
+    offset: usize,
+) -> Result<usize, CpuKernelLaunchError> {
+    let mut remaining = flat;
+    let mut pos = offset;
+    for i in (0..shape.len()).rev() {
+        let dim = shape[i];
+        if dim == 0 {
+            return Err(CpuKernelLaunchError::new(
+                "cpu.fill encountered zero-sized dim while materializing view indices",
+            ));
+        }
+        let idx = remaining % dim;
+        remaining /= dim;
+        let step = idx.checked_mul(strides[i]).ok_or_else(|| {
+            CpuKernelLaunchError::new(format!(
+                "cpu.fill view index calculation overflows at dim {i}"
+            ))
+        })?;
+        pos = pos.checked_add(step).ok_or_else(|| {
+            CpuKernelLaunchError::new("cpu.fill view position calculation overflows")
+        })?;
+    }
+    Ok(pos)
+}
+
 #[cfg(test)]
 mod tests {
-    use schema::{ArgKey, ArgKind, ArgRole, DType, KernelArg, Scalar};
+    use schema::{ArgKey, ArgKind, ArgRole, DType, KernelArg, Scalar, ScalarBuffer};
 
     use super::{launch, output_key, value_key};
     use crate::{CpuBuffer, CpuKernelArgs, CpuKernelLaunchConfig, CpuStorage};
@@ -126,6 +315,87 @@ mod tests {
 
         let values = out.buffer().with_read_bytes(decode_i64_vec);
         assert_eq!(values, vec![7, 7]);
+    }
+
+    #[test]
+    fn launch_fills_only_view_region_when_view_metadata_is_provided() {
+        let mut args = CpuKernelArgs::new();
+        let out = CpuStorage::new(
+            CpuBuffer::new_with_alignment(
+                encode_f32_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]),
+                DType::F32.alignment(),
+            )
+            .expect("aligned buffer creation should succeed"),
+            DType::F32,
+        )
+        .expect("typed storage creation should succeed");
+        args.insert(KernelArg::storage(output_key(), out.clone()))
+            .expect("out insertion should succeed");
+        args.insert(KernelArg::scalar(value_key(DType::F32), Scalar::F32(9.0)))
+            .expect("value insertion should succeed");
+        args.insert(KernelArg::scalar_buffer(
+            super::view_shape_key(),
+            ScalarBuffer::from_bytes(DType::I64, encode_i64_slice(&[2, 2]))
+                .expect("shape metadata buffer should be valid"),
+        ))
+        .expect("shape metadata insertion should succeed");
+        args.insert(KernelArg::scalar_buffer(
+            super::view_strides_key(),
+            ScalarBuffer::from_bytes(DType::I64, encode_i64_slice(&[3, 1]))
+                .expect("strides metadata buffer should be valid"),
+        ))
+        .expect("strides metadata insertion should succeed");
+        args.insert(KernelArg::usize(super::view_offset_key(), 1))
+            .expect("offset metadata insertion should succeed");
+
+        launch(&args, &CpuKernelLaunchConfig::new("cpu.fill"))
+            .expect("fill launch with view metadata should succeed");
+
+        let values = out.buffer().with_read_bytes(decode_f32_vec);
+        assert_eq!(values, vec![0.0, 9.0, 9.0, 3.0, 9.0, 9.0]);
+    }
+
+    #[test]
+    fn launch_rejects_partial_view_metadata() {
+        let mut args = CpuKernelArgs::new();
+        args.insert(KernelArg::storage(
+            output_key(),
+            CpuStorage::new(
+                CpuBuffer::new_with_alignment(vec![0u8; 16], DType::F32.alignment())
+                    .expect("aligned buffer creation should succeed"),
+                DType::F32,
+            )
+            .expect("typed storage creation should succeed"),
+        ))
+        .expect("out insertion should succeed");
+        args.insert(KernelArg::scalar(value_key(DType::F32), Scalar::F32(1.0)))
+            .expect("value insertion should succeed");
+        args.insert(KernelArg::scalar_buffer(
+            super::view_shape_key(),
+            ScalarBuffer::from_bytes(DType::I64, encode_i64_slice(&[2, 2]))
+                .expect("shape metadata buffer should be valid"),
+        ))
+        .expect("shape metadata insertion should succeed");
+
+        let err = launch(&args, &CpuKernelLaunchConfig::new("cpu.fill"))
+            .expect_err("fill launch should fail with partial view metadata");
+        assert!(err.message().contains("requires all view metadata"));
+    }
+
+    fn encode_f32_slice(values: &[f32]) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(std::mem::size_of_val(values));
+        for value in values {
+            bytes.extend_from_slice(&value.to_ne_bytes());
+        }
+        bytes
+    }
+
+    fn encode_i64_slice(values: &[i64]) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(std::mem::size_of_val(values));
+        for value in values {
+            bytes.extend_from_slice(&value.to_ne_bytes());
+        }
+        bytes
     }
 
     fn decode_f32_vec(bytes: &[u8]) -> Vec<f32> {

--- a/execution_cpu/src/kernel/cpu/fill.rs
+++ b/execution_cpu/src/kernel/cpu/fill.rs
@@ -1,5 +1,5 @@
 use crate::{CpuKernelArgs, CpuKernelLaunchConfig, CpuKernelLaunchError};
-use schema::{ArgKey, ArgKind, ArgRole, DType, ScalarBuffer, StorageValue};
+use schema::{ArgKey, ArgKind, ArgRole, DType, StorageValue, ViewSpec};
 
 pub fn output_key() -> ArgKey {
     ArgKey::new(ArgRole::Output, "out", ArgKind::Storage)
@@ -9,16 +9,8 @@ fn value_key(dtype: DType) -> ArgKey {
     ArgKey::new(ArgRole::Param, "value", dtype.value_arg_kind())
 }
 
-fn view_shape_key() -> ArgKey {
-    ArgKey::new(ArgRole::Param, "view_shape", ArgKind::ScalarBuffer)
-}
-
-fn view_strides_key() -> ArgKey {
-    ArgKey::new(ArgRole::Param, "view_strides", ArgKind::ScalarBuffer)
-}
-
-fn view_offset_key() -> ArgKey {
-    ArgKey::new(ArgRole::Param, "view_offset", ArgKind::Usize)
+fn view_spec_key() -> ArgKey {
+    ArgKey::new(ArgRole::Param, "view_spec", ArgKind::ViewSpec)
 }
 
 pub fn launch(
@@ -54,40 +46,25 @@ pub fn launch(
     out_storage
         .buffer()
         .with_write_bytes(|out| -> Result<(), CpuKernelLaunchError> {
-            match &view_spec {
-                Some(spec) => {
-                    for flat in 0..spec.numel {
-                        let pos = flat_to_pos(flat, &spec.shape, &spec.strides, spec.offset)?;
-                        let b = pos.checked_mul(element_bytes).ok_or_else(|| {
-                            CpuKernelLaunchError::new(format!(
-                                "cpu.fill view position {pos} overflows byte offset calculation"
-                            ))
-                        })?;
-                        let e = b.checked_add(element_bytes).ok_or_else(|| {
-                            CpuKernelLaunchError::new(format!(
-                                "cpu.fill view position {pos} overflows byte range calculation"
-                            ))
-                        })?;
-                        let Some(slot) = out.get_mut(b..e) else {
-                            return Err(CpuKernelLaunchError::new(format!(
-                                "cpu.fill view position {pos} (byte range {b}..{e}) is out of bounds for output buffer of {} bytes",
-                                out.len()
-                            )));
-                        };
-                        slot.copy_from_slice(pattern.as_slice());
-                    }
-                }
-                None => {
-                    if out.len() % element_bytes != 0 {
-                        return Err(CpuKernelLaunchError::new(format!(
-                            "cpu.fill requires output byte-size to be multiple of element size {element_bytes}"
-                        )));
-                    }
-
-                    for chunk in out.chunks_exact_mut(element_bytes) {
-                        chunk.copy_from_slice(pattern.as_slice());
-                    }
-                }
+            for flat in 0..view_spec.numel {
+                let pos = flat_to_pos(flat, &view_spec.shape, &view_spec.strides, view_spec.offset)?;
+                let b = pos.checked_mul(element_bytes).ok_or_else(|| {
+                    CpuKernelLaunchError::new(format!(
+                        "cpu.fill view position {pos} overflows byte offset calculation"
+                    ))
+                })?;
+                let e = b.checked_add(element_bytes).ok_or_else(|| {
+                    CpuKernelLaunchError::new(format!(
+                        "cpu.fill view position {pos} overflows byte range calculation"
+                    ))
+                })?;
+                let Some(slot) = out.get_mut(b..e) else {
+                    return Err(CpuKernelLaunchError::new(format!(
+                        "cpu.fill view position {pos} (byte range {b}..{e}) is out of bounds for output buffer of {} bytes",
+                        out.len()
+                    )));
+                };
+                slot.copy_from_slice(pattern.as_slice());
             }
             Ok(())
         })?;
@@ -103,108 +80,32 @@ struct FillViewSpec {
     numel: usize,
 }
 
-fn parse_view_spec(args: &CpuKernelArgs) -> Result<Option<FillViewSpec>, CpuKernelLaunchError> {
-    let shape_key = view_shape_key();
-    let strides_key = view_strides_key();
-    let offset_key = view_offset_key();
+fn parse_view_spec(args: &CpuKernelArgs) -> Result<FillViewSpec, CpuKernelLaunchError> {
+    let view_key = view_spec_key();
 
-    let has_shape = args.args().iter().any(|arg| arg.key() == &shape_key);
-    let has_strides = args.args().iter().any(|arg| arg.key() == &strides_key);
-    let has_offset = args.args().iter().any(|arg| arg.key() == &offset_key);
-
-    if !(has_shape || has_strides || has_offset) {
-        return Ok(None);
-    }
-
-    if !(has_shape && has_strides && has_offset) {
-        return Err(CpuKernelLaunchError::new(
-            "cpu.fill view mode requires all view metadata args: view_shape, view_strides, view_offset",
-        ));
-    }
-
-    let shape = decode_usize_buffer(
-        args.args()
-            .require_scalar_buffer(&shape_key)
-            .map_err(|err| {
-                CpuKernelLaunchError::new(format!(
-                    "cpu.fill requires scalar-buffer param arg '{}': {err:?}",
-                    shape_key.tag().as_str()
-                ))
-            })?,
-        shape_key.tag().as_str(),
-    )?;
-    let strides = decode_usize_buffer(
-        args.args()
-            .require_scalar_buffer(&strides_key)
-            .map_err(|err| {
-                CpuKernelLaunchError::new(format!(
-                    "cpu.fill requires scalar-buffer param arg '{}': {err:?}",
-                    strides_key.tag().as_str()
-                ))
-            })?,
-        strides_key.tag().as_str(),
-    )?;
-    let offset = *args
+    let view_spec = args
         .args()
-        .require_as::<usize>(&offset_key)
+        .require_as::<ViewSpec>(&view_key)
         .map_err(|err| {
             CpuKernelLaunchError::new(format!(
-                "cpu.fill requires usize param arg '{}': {err:?}",
-                offset_key.tag().as_str()
+                "cpu.fill requires view-spec param arg '{}': {err:?}",
+                view_key.tag().as_str()
             ))
         })?;
 
-    if shape.len() != strides.len() {
-        return Err(CpuKernelLaunchError::new(format!(
-            "cpu.fill view metadata requires same rank for shape/strides, got shape={} and strides={}",
-            shape.len(),
-            strides.len()
-        )));
-    }
-
-    let numel = shape
-        .iter()
-        .try_fold(1usize, |acc, &dim| acc.checked_mul(dim).ok_or(()));
-    let numel = numel.map_err(|_| {
-        CpuKernelLaunchError::new("cpu.fill view shape overflows numel calculation")
+    let shape = view_spec.shape().to_vec();
+    let strides = view_spec.strides().to_vec();
+    let offset = view_spec.offset();
+    let numel = view_spec.checked_numel().map_err(|err| {
+        CpuKernelLaunchError::new(format!("cpu.fill view metadata is invalid: {err:?}"))
     })?;
 
-    Ok(Some(FillViewSpec {
+    Ok(FillViewSpec {
         shape,
         strides,
         offset,
         numel,
-    }))
-}
-
-fn decode_usize_buffer(
-    buffer: &ScalarBuffer,
-    arg_tag: &str,
-) -> Result<Vec<usize>, CpuKernelLaunchError> {
-    let raw = buffer.try_to_vec::<i64>().map_err(|err| {
-        CpuKernelLaunchError::new(format!(
-            "cpu.fill requires scalar-buffer arg '{}' to decode as i64 values: {err:?}",
-            arg_tag
-        ))
-    })?;
-
-    let mut values = Vec::with_capacity(raw.len());
-    for value in raw {
-        if value < 0 {
-            return Err(CpuKernelLaunchError::new(format!(
-                "cpu.fill requires scalar-buffer arg '{}' to contain non-negative i64 values",
-                arg_tag
-            )));
-        }
-        values.push(usize::try_from(value).map_err(|_| {
-            CpuKernelLaunchError::new(format!(
-                "cpu.fill scalar-buffer arg '{}' value {value} overflows usize",
-                arg_tag
-            ))
-        })?);
-    }
-
-    Ok(values)
+    })
 }
 
 fn flat_to_pos(
@@ -238,7 +139,7 @@ fn flat_to_pos(
 
 #[cfg(test)]
 mod tests {
-    use schema::{ArgKey, ArgKind, ArgRole, DType, KernelArg, Scalar, ScalarBuffer};
+    use schema::{ArgKey, ArgKind, ArgRole, DType, KernelArg, Scalar, ViewSpec};
 
     use super::{launch, output_key, value_key};
     use crate::{CpuBuffer, CpuKernelArgs, CpuKernelLaunchConfig, CpuStorage};
@@ -256,6 +157,11 @@ mod tests {
             .expect("out insertion should succeed");
         args.insert(KernelArg::scalar(value_key(DType::F32), Scalar::F32(3.0)))
             .expect("value insertion should succeed");
+        args.insert(KernelArg::view_spec(
+            super::view_spec_key(),
+            ViewSpec::new(vec![4], vec![1], 0).expect("view metadata should be valid"),
+        ))
+        .expect("view metadata insertion should succeed");
 
         launch(&args, &CpuKernelLaunchConfig::new("cpu.fill"))
             .expect("fill launch should validate arguments");
@@ -276,6 +182,11 @@ mod tests {
             .expect("typed storage creation should succeed"),
         ))
         .expect("out insertion should succeed");
+        args.insert(KernelArg::view_spec(
+            super::view_spec_key(),
+            ViewSpec::new(vec![2], vec![1], 0).expect("view metadata should be valid"),
+        ))
+        .expect("view metadata insertion should succeed");
 
         let err = launch(&args, &CpuKernelLaunchConfig::new("cpu.fill"))
             .expect_err("fill launch should fail without value");
@@ -298,6 +209,11 @@ mod tests {
             .expect("out insertion should succeed");
         args.insert(KernelArg::scalar(value_key(DType::I64), Scalar::I64(7)))
             .expect("value insertion should succeed");
+        args.insert(KernelArg::view_spec(
+            super::view_spec_key(),
+            ViewSpec::new(vec![2], vec![1], 0).expect("view metadata should be valid"),
+        ))
+        .expect("view metadata insertion should succeed");
 
         launch(&args, &CpuKernelLaunchConfig::new("cpu.fill"))
             .expect("fill launch should validate arguments");
@@ -322,20 +238,11 @@ mod tests {
             .expect("out insertion should succeed");
         args.insert(KernelArg::scalar(value_key(DType::F32), Scalar::F32(9.0)))
             .expect("value insertion should succeed");
-        args.insert(KernelArg::scalar_buffer(
-            super::view_shape_key(),
-            ScalarBuffer::from_bytes(DType::I64, encode_i64_slice(&[2, 2]))
-                .expect("shape metadata buffer should be valid"),
+        args.insert(KernelArg::view_spec(
+            super::view_spec_key(),
+            ViewSpec::new(vec![2, 2], vec![3, 1], 1).expect("view metadata should be valid"),
         ))
-        .expect("shape metadata insertion should succeed");
-        args.insert(KernelArg::scalar_buffer(
-            super::view_strides_key(),
-            ScalarBuffer::from_bytes(DType::I64, encode_i64_slice(&[3, 1]))
-                .expect("strides metadata buffer should be valid"),
-        ))
-        .expect("strides metadata insertion should succeed");
-        args.insert(KernelArg::usize(super::view_offset_key(), 1))
-            .expect("offset metadata insertion should succeed");
+        .expect("view metadata insertion should succeed");
 
         launch(&args, &CpuKernelLaunchConfig::new("cpu.fill"))
             .expect("fill launch with view metadata should succeed");
@@ -345,7 +252,7 @@ mod tests {
     }
 
     #[test]
-    fn launch_rejects_partial_view_metadata() {
+    fn launch_rejects_missing_view_spec() {
         let mut args = CpuKernelArgs::new();
         args.insert(KernelArg::storage(
             output_key(),
@@ -359,27 +266,40 @@ mod tests {
         .expect("out insertion should succeed");
         args.insert(KernelArg::scalar(value_key(DType::F32), Scalar::F32(1.0)))
             .expect("value insertion should succeed");
-        args.insert(KernelArg::scalar_buffer(
-            super::view_shape_key(),
-            ScalarBuffer::from_bytes(DType::I64, encode_i64_slice(&[2, 2]))
-                .expect("shape metadata buffer should be valid"),
-        ))
-        .expect("shape metadata insertion should succeed");
 
         let err = launch(&args, &CpuKernelLaunchConfig::new("cpu.fill"))
-            .expect_err("fill launch should fail with partial view metadata");
-        assert!(err.message().contains("requires all view metadata"));
+            .expect_err("fill launch should fail without view metadata");
+        assert!(err.message().contains("view-spec"));
+    }
+
+    #[test]
+    fn launch_rejects_invalid_view_spec_numel_overflow() {
+        let mut args = CpuKernelArgs::new();
+        args.insert(KernelArg::storage(
+            output_key(),
+            CpuStorage::new(
+                CpuBuffer::new_with_alignment(vec![0u8; 16], DType::F32.alignment())
+                    .expect("aligned buffer creation should succeed"),
+                DType::F32,
+            )
+            .expect("typed storage creation should succeed"),
+        ))
+        .expect("out insertion should succeed");
+        args.insert(KernelArg::scalar(value_key(DType::F32), Scalar::F32(1.0)))
+            .expect("value insertion should succeed");
+        args.insert(KernelArg::view_spec(
+            super::view_spec_key(),
+            ViewSpec::new(vec![usize::MAX, 2], vec![1, 1], 0)
+                .expect("rank-matched view metadata should be constructible"),
+        ))
+        .expect("view metadata insertion should succeed");
+
+        let err = launch(&args, &CpuKernelLaunchConfig::new("cpu.fill"))
+            .expect_err("fill launch should fail for invalid view metadata");
+        assert!(err.message().contains("invalid"));
     }
 
     fn encode_f32_slice(values: &[f32]) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(std::mem::size_of_val(values));
-        for value in values {
-            bytes.extend_from_slice(&value.to_ne_bytes());
-        }
-        bytes
-    }
-
-    fn encode_i64_slice(values: &[i64]) -> Vec<u8> {
         let mut bytes = Vec::with_capacity(std::mem::size_of_val(values));
         for value in values {
             bytes.extend_from_slice(&value.to_ne_bytes());

--- a/execution_cpu/src/kernel/cpu/fill.rs
+++ b/execution_cpu/src/kernel/cpu/fill.rs
@@ -18,6 +18,7 @@ pub fn launch(
     _launch_config: &CpuKernelLaunchConfig,
 ) -> Result<(), CpuKernelLaunchError> {
     let out_key = output_key();
+    let view_key = view_spec_key();
 
     let out_storage = args
         .args()
@@ -41,13 +42,29 @@ pub fn launch(
                 value_key.tag().as_str()
             ))
         })?;
+    let view_spec = args
+        .args()
+        .require_as::<ViewSpec>(&view_key)
+        .map_err(|err| {
+            CpuKernelLaunchError::new(format!(
+                "cpu.fill requires view-spec param arg '{}': {err:?}",
+                view_key.tag().as_str()
+            ))
+        })?;
     let element_bytes = dtype.size_bytes();
-    let view_spec = parse_view_spec(args)?;
+    let numel = view_spec.checked_numel().map_err(|err| {
+        CpuKernelLaunchError::new(format!("cpu.fill view metadata is invalid: {err:?}"))
+    })?;
     out_storage
         .buffer()
         .with_write_bytes(|out| -> Result<(), CpuKernelLaunchError> {
-            for flat in 0..view_spec.numel {
-                let pos = flat_to_pos(flat, &view_spec.shape, &view_spec.strides, view_spec.offset)?;
+            for flat in 0..numel {
+                let pos = flat_to_pos(
+                    flat,
+                    view_spec.shape(),
+                    view_spec.strides(),
+                    view_spec.offset(),
+                )?;
                 let b = pos.checked_mul(element_bytes).ok_or_else(|| {
                     CpuKernelLaunchError::new(format!(
                         "cpu.fill view position {pos} overflows byte offset calculation"
@@ -70,42 +87,6 @@ pub fn launch(
         })?;
 
     Ok(())
-}
-
-#[derive(Debug, Clone)]
-struct FillViewSpec {
-    shape: Vec<usize>,
-    strides: Vec<usize>,
-    offset: usize,
-    numel: usize,
-}
-
-fn parse_view_spec(args: &CpuKernelArgs) -> Result<FillViewSpec, CpuKernelLaunchError> {
-    let view_key = view_spec_key();
-
-    let view_spec = args
-        .args()
-        .require_as::<ViewSpec>(&view_key)
-        .map_err(|err| {
-            CpuKernelLaunchError::new(format!(
-                "cpu.fill requires view-spec param arg '{}': {err:?}",
-                view_key.tag().as_str()
-            ))
-        })?;
-
-    let shape = view_spec.shape().to_vec();
-    let strides = view_spec.strides().to_vec();
-    let offset = view_spec.offset();
-    let numel = view_spec.checked_numel().map_err(|err| {
-        CpuKernelLaunchError::new(format!("cpu.fill view metadata is invalid: {err:?}"))
-    })?;
-
-    Ok(FillViewSpec {
-        shape,
-        strides,
-        offset,
-        numel,
-    })
 }
 
 fn flat_to_pos(

--- a/execution_cpu/src/kernel/cpu/read_at.rs
+++ b/execution_cpu/src/kernel/cpu/read_at.rs
@@ -1,4 +1,4 @@
-use schema::{ArgKey, ArgKind, ArgRole, StorageValue};
+use schema::{ArgKey, ArgKind, ArgRole, StorageValue, ViewSpec};
 
 use crate::{CpuKernelArgs, CpuKernelLaunchConfig, CpuKernelLaunchError};
 
@@ -10,8 +10,12 @@ pub fn output_key() -> ArgKey {
     ArgKey::new(ArgRole::Output, "out", ArgKind::Storage)
 }
 
-pub fn pos_key() -> ArgKey {
-    ArgKey::new(ArgRole::Param, "pos", ArgKind::Usize)
+pub fn view_spec_key() -> ArgKey {
+    ArgKey::new(ArgRole::Param, "view_spec", ArgKind::ViewSpec)
+}
+
+pub fn indices_key() -> ArgKey {
+    ArgKey::new(ArgRole::Param, "indices", ArgKind::ScalarBuffer)
 }
 
 pub fn launch(
@@ -20,7 +24,8 @@ pub fn launch(
 ) -> Result<(), CpuKernelLaunchError> {
     let in_key = input_key();
     let out_key = output_key();
-    let pos_key = pos_key();
+    let view_key = view_spec_key();
+    let indices_key = indices_key();
 
     let in_storage = args
         .args()
@@ -42,11 +47,33 @@ pub fn launch(
             ))
         })?;
 
-    let pos = *args.args().require_as::<usize>(&pos_key).map_err(|err| {
-        CpuKernelLaunchError::new(format!(
-            "cpu.read_at requires usize param arg '{}': {err:?}",
-            pos_key.tag().as_str()
-        ))
+    let view_spec = args
+        .args()
+        .require_as::<ViewSpec>(&view_key)
+        .map_err(|err| {
+            CpuKernelLaunchError::new(format!(
+                "cpu.read_at requires view-spec param arg '{}': {err:?}",
+                view_key.tag().as_str()
+            ))
+        })?;
+    let indices = args
+        .args()
+        .require_scalar_buffer(&indices_key)
+        .map_err(|err| {
+            CpuKernelLaunchError::new(format!(
+                "cpu.read_at requires scalar-buffer param arg '{}': {err:?}",
+                indices_key.tag().as_str()
+            ))
+        })?
+        .try_to_vec::<i64>()
+        .map_err(|err| {
+            CpuKernelLaunchError::new(format!(
+                "cpu.read_at requires scalar-buffer arg '{}' to decode as i64 values: {err:?}",
+                indices_key.tag().as_str()
+            ))
+        })?;
+    let pos = view_spec.checked_pos_i64(&indices).map_err(|err| {
+        CpuKernelLaunchError::new(format!("cpu.read_at invalid view/index metadata: {err:?}"))
     })?;
 
     if in_storage.dtype() != out_storage.dtype() {
@@ -97,9 +124,9 @@ pub fn launch(
 
 #[cfg(test)]
 mod tests {
-    use schema::{DType, KernelArg};
+    use schema::{DType, KernelArg, ScalarBuffer, ViewSpec};
 
-    use super::{input_key, launch, output_key, pos_key};
+    use super::{indices_key, input_key, launch, output_key, view_spec_key};
     use crate::{CpuBuffer, CpuKernelArgs, CpuKernelLaunchConfig, CpuStorage};
 
     #[test]
@@ -124,8 +151,17 @@ mod tests {
             .expect("in insertion should succeed");
         args.insert(KernelArg::storage(output_key(), out.clone()))
             .expect("out insertion should succeed");
-        args.insert(KernelArg::usize(pos_key(), 1))
-            .expect("pos insertion should succeed");
+        args.insert(KernelArg::view_spec(
+            view_spec_key(),
+            ViewSpec::new(vec![3], vec![1], 0).expect("view metadata should be valid"),
+        ))
+        .expect("view spec insertion should succeed");
+        args.insert(KernelArg::scalar_buffer(
+            indices_key(),
+            ScalarBuffer::from_bytes(DType::I64, encode_i64_slice(&[1]))
+                .expect("indices metadata should be valid"),
+        ))
+        .expect("indices insertion should succeed");
 
         launch(&args, &CpuKernelLaunchConfig::new("cpu.read_at"))
             .expect("read_at launch should succeed");
@@ -155,12 +191,21 @@ mod tests {
             .expect("in insertion should succeed");
         args.insert(KernelArg::storage(output_key(), out))
             .expect("out insertion should succeed");
-        args.insert(KernelArg::usize(pos_key(), 2))
-            .expect("pos insertion should succeed");
+        args.insert(KernelArg::view_spec(
+            view_spec_key(),
+            ViewSpec::new(vec![2], vec![1], 0).expect("view metadata should be valid"),
+        ))
+        .expect("view spec insertion should succeed");
+        args.insert(KernelArg::scalar_buffer(
+            indices_key(),
+            ScalarBuffer::from_bytes(DType::I64, encode_i64_slice(&[2]))
+                .expect("indices metadata should be valid"),
+        ))
+        .expect("indices insertion should succeed");
 
         let err = launch(&args, &CpuKernelLaunchConfig::new("cpu.read_at"))
             .expect_err("read_at launch should fail for out-of-bounds position");
-        assert!(err.message().contains("out of bounds"));
+        assert!(err.message().contains("IndexOutOfBounds"));
     }
 
     #[test]
@@ -182,8 +227,17 @@ mod tests {
             .expect("in insertion should succeed");
         args.insert(KernelArg::storage(output_key(), out.clone()))
             .expect("out insertion should succeed");
-        args.insert(KernelArg::usize(pos_key(), 1))
-            .expect("pos insertion should succeed");
+        args.insert(KernelArg::view_spec(
+            view_spec_key(),
+            ViewSpec::new(vec![3], vec![1], 0).expect("view metadata should be valid"),
+        ))
+        .expect("view spec insertion should succeed");
+        args.insert(KernelArg::scalar_buffer(
+            indices_key(),
+            ScalarBuffer::from_bytes(DType::I64, encode_i64_slice(&[1]))
+                .expect("indices metadata should be valid"),
+        ))
+        .expect("indices insertion should succeed");
 
         launch(&args, &CpuKernelLaunchConfig::new("cpu.read_at"))
             .expect("read_at launch should succeed");

--- a/execution_cpu/src/kernel/cpu/read_at.rs
+++ b/execution_cpu/src/kernel/cpu/read_at.rs
@@ -1,4 +1,4 @@
-use schema::{ArgKey, ArgKind, ArgRole, StorageValue, ViewSpec};
+use schema::{ArgKey, ArgKind, ArgRole, DType, StorageValue, ViewSpec};
 
 use crate::{CpuKernelArgs, CpuKernelLaunchConfig, CpuKernelLaunchError};
 
@@ -56,7 +56,7 @@ pub fn launch(
                 view_key.tag().as_str()
             ))
         })?;
-    let indices = args
+    let indices_buffer = args
         .args()
         .require_scalar_buffer(&indices_key)
         .map_err(|err| {
@@ -64,7 +64,22 @@ pub fn launch(
                 "cpu.read_at requires scalar-buffer param arg '{}': {err:?}",
                 indices_key.tag().as_str()
             ))
-        })?
+        })?;
+    if indices_buffer.dtype() != DType::I64 {
+        return Err(CpuKernelLaunchError::new(format!(
+            "cpu.read_at requires scalar-buffer arg '{}' to decode as i64 values: DTypeMismatch {{ expected: I64, actual: {:?} }}",
+            indices_key.tag().as_str(),
+            indices_buffer.dtype()
+        )));
+    }
+    let expected_rank = view_spec.rank();
+    let actual_rank = indices_buffer.len();
+    if actual_rank != expected_rank {
+        return Err(CpuKernelLaunchError::new(format!(
+            "cpu.read_at invalid view/index metadata: IndicesRankMismatch {{ expected_rank: {expected_rank}, actual_rank: {actual_rank} }}"
+        )));
+    }
+    let indices = indices_buffer
         .try_to_vec::<i64>()
         .map_err(|err| {
             CpuKernelLaunchError::new(format!(
@@ -248,6 +263,42 @@ mod tests {
             ])
         });
         assert_eq!(value, 22);
+    }
+
+    #[test]
+    fn launch_rejects_indices_rank_mismatch() {
+        let mut args = CpuKernelArgs::new();
+        let input = CpuStorage::new(
+            CpuBuffer::new_with_alignment(vec![0u8; 4], DType::F32.alignment())
+                .expect("aligned buffer creation should succeed"),
+            DType::F32,
+        )
+        .expect("typed storage creation should succeed");
+        let out = CpuStorage::new(
+            CpuBuffer::new_with_alignment(vec![0u8; 4], DType::F32.alignment())
+                .expect("aligned buffer creation should succeed"),
+            DType::F32,
+        )
+        .expect("typed storage creation should succeed");
+        args.insert(KernelArg::storage(input_key(), input))
+            .expect("in insertion should succeed");
+        args.insert(KernelArg::storage(output_key(), out))
+            .expect("out insertion should succeed");
+        args.insert(KernelArg::view_spec(
+            view_spec_key(),
+            ViewSpec::new(vec![1, 1], vec![1, 1], 0).expect("view metadata should be valid"),
+        ))
+        .expect("view spec insertion should succeed");
+        args.insert(KernelArg::scalar_buffer(
+            indices_key(),
+            ScalarBuffer::from_bytes(DType::I64, encode_i64_slice(&[0]))
+                .expect("indices metadata should be valid"),
+        ))
+        .expect("indices insertion should succeed");
+
+        let err = launch(&args, &CpuKernelLaunchConfig::new("cpu.read_at"))
+            .expect_err("read_at launch should fail for indices rank mismatch");
+        assert!(err.message().contains("IndicesRankMismatch"));
     }
 
     fn encode_f32_slice(values: &[f32]) -> Vec<u8> {

--- a/execution_cpu/src/kernel/cpu/read_at.rs
+++ b/execution_cpu/src/kernel/cpu/read_at.rs
@@ -79,14 +79,12 @@ pub fn launch(
             "cpu.read_at invalid view/index metadata: IndicesRankMismatch {{ expected_rank: {expected_rank}, actual_rank: {actual_rank} }}"
         )));
     }
-    let indices = indices_buffer
-        .try_to_vec::<i64>()
-        .map_err(|err| {
-            CpuKernelLaunchError::new(format!(
-                "cpu.read_at requires scalar-buffer arg '{}' to decode as i64 values: {err:?}",
-                indices_key.tag().as_str()
-            ))
-        })?;
+    let indices = indices_buffer.try_to_vec::<i64>().map_err(|err| {
+        CpuKernelLaunchError::new(format!(
+            "cpu.read_at requires scalar-buffer arg '{}' to decode as i64 values: {err:?}",
+            indices_key.tag().as_str()
+        ))
+    })?;
     let pos = view_spec.checked_pos_i64(&indices).map_err(|err| {
         CpuKernelLaunchError::new(format!("cpu.read_at invalid view/index metadata: {err:?}"))
     })?;

--- a/execution_cpu/src/kernel/cpu/write_at.rs
+++ b/execution_cpu/src/kernel/cpu/write_at.rs
@@ -1,12 +1,16 @@
 use crate::{CpuKernelArgs, CpuKernelLaunchConfig, CpuKernelLaunchError};
-use schema::{ArgKey, ArgKind, ArgRole, DType, StorageValue};
+use schema::{ArgKey, ArgKind, ArgRole, DType, StorageValue, ViewSpec};
 
 pub fn output_key() -> ArgKey {
     ArgKey::new(ArgRole::Output, "out", ArgKind::Storage)
 }
 
-pub fn pos_key() -> ArgKey {
-    ArgKey::new(ArgRole::Param, "pos", ArgKind::Usize)
+pub fn view_spec_key() -> ArgKey {
+    ArgKey::new(ArgRole::Param, "view_spec", ArgKind::ViewSpec)
+}
+
+pub fn indices_key() -> ArgKey {
+    ArgKey::new(ArgRole::Param, "indices", ArgKind::ScalarBuffer)
 }
 
 fn value_key(dtype: DType) -> ArgKey {
@@ -18,7 +22,8 @@ pub fn launch(
     _launch_config: &CpuKernelLaunchConfig,
 ) -> Result<(), CpuKernelLaunchError> {
     let out_key = output_key();
-    let pos_key = pos_key();
+    let view_key = view_spec_key();
+    let indices_key = indices_key();
 
     let out_storage = args
         .args()
@@ -30,11 +35,33 @@ pub fn launch(
             ))
         })?;
 
-    let pos = *args.args().require_as::<usize>(&pos_key).map_err(|err| {
-        CpuKernelLaunchError::new(format!(
-            "cpu.write_at requires usize param arg '{}': {err:?}",
-            pos_key.tag().as_str()
-        ))
+    let view_spec = args
+        .args()
+        .require_as::<ViewSpec>(&view_key)
+        .map_err(|err| {
+            CpuKernelLaunchError::new(format!(
+                "cpu.write_at requires view-spec param arg '{}': {err:?}",
+                view_key.tag().as_str()
+            ))
+        })?;
+    let indices = args
+        .args()
+        .require_scalar_buffer(&indices_key)
+        .map_err(|err| {
+            CpuKernelLaunchError::new(format!(
+                "cpu.write_at requires scalar-buffer param arg '{}': {err:?}",
+                indices_key.tag().as_str()
+            ))
+        })?
+        .try_to_vec::<i64>()
+        .map_err(|err| {
+            CpuKernelLaunchError::new(format!(
+                "cpu.write_at requires scalar-buffer arg '{}' to decode as i64 values: {err:?}",
+                indices_key.tag().as_str()
+            ))
+        })?;
+    let pos = view_spec.checked_pos_i64(&indices).map_err(|err| {
+        CpuKernelLaunchError::new(format!("cpu.write_at invalid view/index metadata: {err:?}"))
     })?;
 
     let dtype = out_storage.dtype();
@@ -77,9 +104,9 @@ pub fn launch(
 
 #[cfg(test)]
 mod tests {
-    use schema::{DType, KernelArg, Scalar};
+    use schema::{DType, KernelArg, Scalar, ScalarBuffer, ViewSpec};
 
-    use super::{launch, output_key, pos_key, value_key};
+    use super::{indices_key, launch, output_key, value_key, view_spec_key};
     use crate::{CpuBuffer, CpuKernelArgs, CpuKernelLaunchConfig, CpuStorage};
 
     #[test]
@@ -93,8 +120,17 @@ mod tests {
         .expect("typed storage creation should succeed");
         args.insert(KernelArg::storage(output_key(), out.clone()))
             .expect("out insertion should succeed");
-        args.insert(KernelArg::usize(pos_key(), 2))
-            .expect("pos insertion should succeed");
+        args.insert(KernelArg::view_spec(
+            view_spec_key(),
+            ViewSpec::new(vec![4], vec![1], 0).expect("view metadata should be valid"),
+        ))
+        .expect("view metadata insertion should succeed");
+        args.insert(KernelArg::scalar_buffer(
+            indices_key(),
+            ScalarBuffer::from_bytes(DType::I64, encode_i64_slice(&[2]))
+                .expect("indices metadata should be valid"),
+        ))
+        .expect("indices insertion should succeed");
         args.insert(KernelArg::scalar(value_key(DType::F32), Scalar::F32(7.5)))
             .expect("value insertion should succeed");
 
@@ -116,14 +152,23 @@ mod tests {
         .expect("typed storage creation should succeed");
         args.insert(KernelArg::storage(output_key(), out))
             .expect("out insertion should succeed");
-        args.insert(KernelArg::usize(pos_key(), 2))
-            .expect("pos insertion should succeed");
+        args.insert(KernelArg::view_spec(
+            view_spec_key(),
+            ViewSpec::new(vec![2], vec![1], 0).expect("view metadata should be valid"),
+        ))
+        .expect("view metadata insertion should succeed");
+        args.insert(KernelArg::scalar_buffer(
+            indices_key(),
+            ScalarBuffer::from_bytes(DType::I64, encode_i64_slice(&[2]))
+                .expect("indices metadata should be valid"),
+        ))
+        .expect("indices insertion should succeed");
         args.insert(KernelArg::scalar(value_key(DType::F32), Scalar::F32(1.25)))
             .expect("value insertion should succeed");
 
         let err = launch(&args, &CpuKernelLaunchConfig::new("cpu.write_at"))
             .expect_err("write_at launch should fail for out-of-bounds position");
-        assert!(err.message().contains("out of bounds"));
+        assert!(err.message().contains("IndexOutOfBounds"));
     }
 
     #[test]
@@ -137,8 +182,17 @@ mod tests {
         .expect("typed storage creation should succeed");
         args.insert(KernelArg::storage(output_key(), out.clone()))
             .expect("out insertion should succeed");
-        args.insert(KernelArg::usize(pos_key(), 1))
-            .expect("pos insertion should succeed");
+        args.insert(KernelArg::view_spec(
+            view_spec_key(),
+            ViewSpec::new(vec![3], vec![1], 0).expect("view metadata should be valid"),
+        ))
+        .expect("view metadata insertion should succeed");
+        args.insert(KernelArg::scalar_buffer(
+            indices_key(),
+            ScalarBuffer::from_bytes(DType::I64, encode_i64_slice(&[1]))
+                .expect("indices metadata should be valid"),
+        ))
+        .expect("indices insertion should succeed");
         args.insert(KernelArg::scalar(value_key(DType::I64), Scalar::I64(9)))
             .expect("value insertion should succeed");
 
@@ -171,5 +225,13 @@ mod tests {
             .collect();
         assert!(chunks.remainder().is_empty());
         values
+    }
+
+    fn encode_i64_slice(values: &[i64]) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(std::mem::size_of_val(values));
+        for value in values {
+            bytes.extend_from_slice(&value.to_ne_bytes());
+        }
+        bytes
     }
 }

--- a/execution_cpu/src/kernel/cpu/write_at.rs
+++ b/execution_cpu/src/kernel/cpu/write_at.rs
@@ -52,7 +52,22 @@ pub fn launch(
                 "cpu.write_at requires scalar-buffer param arg '{}': {err:?}",
                 indices_key.tag().as_str()
             ))
-        })?
+        })?;
+    if indices.dtype() != DType::I64 {
+        return Err(CpuKernelLaunchError::new(format!(
+            "cpu.write_at requires scalar-buffer arg '{}' to decode as i64 values: DTypeMismatch {{ expected: I64, actual: {:?} }}",
+            indices_key.tag().as_str(),
+            indices.dtype()
+        )));
+    }
+    let expected_rank = view_spec.rank();
+    let actual_rank = indices.len();
+    if actual_rank != expected_rank {
+        return Err(CpuKernelLaunchError::new(format!(
+            "cpu.write_at invalid view/index metadata: IndicesRankMismatch {{ expected_rank: {expected_rank}, actual_rank: {actual_rank} }}"
+        )));
+    }
+    let indices = indices
         .try_to_vec::<i64>()
         .map_err(|err| {
             CpuKernelLaunchError::new(format!(
@@ -201,6 +216,36 @@ mod tests {
 
         let values = out.buffer().with_read_bytes(decode_i64_vec);
         assert_eq!(values, vec![0, 9, 0]);
+    }
+
+    #[test]
+    fn launch_rejects_indices_rank_mismatch() {
+        let mut args = CpuKernelArgs::new();
+        let out = CpuStorage::new(
+            CpuBuffer::new_with_alignment(vec![0u8; 4], DType::F32.alignment())
+                .expect("aligned buffer creation should succeed"),
+            DType::F32,
+        )
+        .expect("typed storage creation should succeed");
+        args.insert(KernelArg::storage(output_key(), out))
+            .expect("out insertion should succeed");
+        args.insert(KernelArg::view_spec(
+            view_spec_key(),
+            ViewSpec::new(vec![1, 1], vec![1, 1], 0).expect("view metadata should be valid"),
+        ))
+        .expect("view metadata insertion should succeed");
+        args.insert(KernelArg::scalar_buffer(
+            indices_key(),
+            ScalarBuffer::from_bytes(DType::I64, encode_i64_slice(&[0]))
+                .expect("indices metadata should be valid"),
+        ))
+        .expect("indices insertion should succeed");
+        args.insert(KernelArg::scalar(value_key(DType::F32), Scalar::F32(1.25)))
+            .expect("value insertion should succeed");
+
+        let err = launch(&args, &CpuKernelLaunchConfig::new("cpu.write_at"))
+            .expect_err("write_at launch should fail for indices rank mismatch");
+        assert!(err.message().contains("IndicesRankMismatch"));
     }
 
     fn decode_f32_vec(bytes: &[u8]) -> Vec<f32> {

--- a/execution_cpu/src/kernel/cpu/write_at.rs
+++ b/execution_cpu/src/kernel/cpu/write_at.rs
@@ -67,14 +67,12 @@ pub fn launch(
             "cpu.write_at invalid view/index metadata: IndicesRankMismatch {{ expected_rank: {expected_rank}, actual_rank: {actual_rank} }}"
         )));
     }
-    let indices = indices
-        .try_to_vec::<i64>()
-        .map_err(|err| {
-            CpuKernelLaunchError::new(format!(
-                "cpu.write_at requires scalar-buffer arg '{}' to decode as i64 values: {err:?}",
-                indices_key.tag().as_str()
-            ))
-        })?;
+    let indices = indices.try_to_vec::<i64>().map_err(|err| {
+        CpuKernelLaunchError::new(format!(
+            "cpu.write_at requires scalar-buffer arg '{}' to decode as i64 values: {err:?}",
+            indices_key.tag().as_str()
+        ))
+    })?;
     let pos = view_spec.checked_pos_i64(&indices).map_err(|err| {
         CpuKernelLaunchError::new(format!("cpu.write_at invalid view/index metadata: {err:?}"))
     })?;

--- a/execution_cpu/src/storage.rs
+++ b/execution_cpu/src/storage.rs
@@ -189,7 +189,24 @@ impl CpuBuffer {
 }
 
 impl CpuStorage {
+    fn validate_dtype_compatible_len(
+        bytes: usize,
+        dtype: DType,
+    ) -> Result<(), CpuStorageAllocError> {
+        let dtype_size = dtype.size_bytes();
+        if !bytes.is_multiple_of(dtype_size) {
+            return Err(CpuStorageAllocError::InvalidByteSizeForDType {
+                bytes,
+                dtype,
+                dtype_size,
+            });
+        }
+        Ok(())
+    }
+
     pub fn new(buffer: CpuBuffer, dtype: DType) -> Result<Self, CpuStorageAllocError> {
+        Self::validate_dtype_compatible_len(buffer.len_bytes(), dtype)?;
+
         let required_alignment = dtype.alignment();
         let buffer_alignment = buffer.alignment();
         if buffer_alignment < required_alignment {
@@ -207,14 +224,7 @@ impl CpuStorage {
         alignment: Option<usize>,
         dtype: DType,
     ) -> Result<Self, CpuStorageAllocError> {
-        let dtype_size = dtype.size_bytes();
-        if !bytes.is_multiple_of(dtype_size) {
-            return Err(CpuStorageAllocError::InvalidByteSizeForDType {
-                bytes,
-                dtype,
-                dtype_size,
-            });
-        }
+        Self::validate_dtype_compatible_len(bytes, dtype)?;
 
         let requested_alignment = alignment.unwrap_or(dtype.alignment());
         let effective_alignment = requested_alignment.max(dtype.alignment());
@@ -246,5 +256,29 @@ impl execution_contracts::ExecutionStorage for CpuStorage {
 
     fn dtype(&self) -> DType {
         self.dtype()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use schema::DType;
+
+    use super::{CpuBuffer, CpuStorage, CpuStorageAllocError};
+
+    #[test]
+    fn new_rejects_invalid_byte_size_for_dtype() {
+        let buffer = CpuBuffer::new_with_alignment(vec![0u8; 9], DType::I64.alignment())
+            .expect("buffer creation should succeed");
+
+        let err = CpuStorage::new(buffer, DType::I64)
+            .expect_err("typed storage creation should fail for invalid byte size");
+        assert_eq!(
+            err,
+            CpuStorageAllocError::InvalidByteSizeForDType {
+                bytes: 9,
+                dtype: DType::I64,
+                dtype_size: std::mem::size_of::<i64>(),
+            }
+        );
     }
 }

--- a/runtime/src/version/v2/resolver.rs
+++ b/runtime/src/version/v2/resolver.rs
@@ -72,6 +72,7 @@ fn kind_code(kind: schema::ArgKind) -> u8 {
         schema::ArgKind::Scalar(schema::DType::Bool) => 4,
         schema::ArgKind::Scalar(schema::DType::U8) => 5,
         schema::ArgKind::ScalarBuffer => 6,
+        schema::ArgKind::ViewSpec => 7,
     }
 }
 
@@ -90,5 +91,6 @@ mod tests {
         assert_eq!(kind_code(ArgKind::Scalar(schema::DType::Bool)), 4);
         assert_eq!(kind_code(ArgKind::Scalar(schema::DType::U8)), 5);
         assert_eq!(kind_code(ArgKind::ScalarBuffer), 6);
+        assert_eq!(kind_code(ArgKind::ViewSpec), 7);
     }
 }

--- a/schema/src/arg.rs
+++ b/schema/src/arg.rs
@@ -1,4 +1,4 @@
-use crate::{ArgKey, ArgValue, Scalar, ScalarBuffer};
+use crate::{ArgKey, ArgValue, Scalar, ScalarBuffer, ViewSpec};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct KernelArg<S> {
@@ -25,6 +25,10 @@ impl<S> KernelArg<S> {
 
     pub fn usize(key: ArgKey, value: usize) -> Self {
         Self::new(key, ArgValue::Usize(value))
+    }
+
+    pub fn view_spec(key: ArgKey, value: ViewSpec) -> Self {
+        Self::new(key, ArgValue::ViewSpec(value))
     }
 
     pub fn key(&self) -> &ArgKey {

--- a/schema/src/args.rs
+++ b/schema/src/args.rs
@@ -1,5 +1,6 @@
 use crate::{
     ArgKey, ArgValueAccess, DType, EncodedScalar, KernelArg, KernelArgsError, Scalar, ScalarBuffer,
+    ViewSpec,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -104,6 +105,18 @@ impl<S> KernelArgs<S> {
 
     pub fn require_scalar_buffer(&self, key: &ArgKey) -> Result<&ScalarBuffer, KernelArgsError> {
         self.require_as::<ScalarBuffer>(key)
+    }
+
+    pub fn insert_view_spec(
+        &mut self,
+        key: ArgKey,
+        value: ViewSpec,
+    ) -> Result<(), KernelArgsError> {
+        self.insert(KernelArg::view_spec(key, value))
+    }
+
+    pub fn require_view_spec(&self, key: &ArgKey) -> Result<&ViewSpec, KernelArgsError> {
+        self.require_as::<ViewSpec>(key)
     }
 }
 

--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -7,6 +7,7 @@ mod key;
 mod role;
 mod scalar;
 mod scalar_buffer;
+mod stack_vector;
 mod value;
 
 pub use arg::KernelArg;
@@ -17,14 +18,15 @@ pub use error::KernelArgsError;
 pub use key::{ArgKey, ArgTag};
 pub use role::ArgRole;
 pub use scalar::Scalar;
-pub use scalar_buffer::ScalarBuffer;
+pub use scalar_buffer::{ScalarBuffer, ScalarBufferDecodeError, ScalarBufferElement};
+pub use stack_vector::{StackVector, StackVectorError};
 pub use value::{ArgKind, ArgValue, ArgValueAccess, StorageValue};
 
 #[cfg(test)]
 mod tests {
     use super::{
         ArgKey, ArgKind, ArgRole, DType, KernelArg, KernelArgs, KernelArgsError, Scalar,
-        ScalarBuffer, StorageValue,
+        ScalarBuffer, ScalarBufferDecodeError, StackVector, StorageValue,
     };
 
     #[test]
@@ -181,6 +183,59 @@ mod tests {
 
         let not_aligned = ScalarBuffer::from_bytes(DType::I64, vec![0u8; 7]);
         assert!(not_aligned.is_none());
+    }
+
+    #[test]
+    fn scalar_buffer_try_to_vec_supports_typed_decode() {
+        let values = ScalarBuffer::from_bytes(
+            DType::I64,
+            [1i64, 2, 3]
+                .into_iter()
+                .flat_map(i64::to_ne_bytes)
+                .collect::<Vec<u8>>(),
+        )
+        .expect("valid scalar buffer should be created");
+
+        let decoded = values
+            .try_to_vec::<i64>()
+            .expect("typed decode should succeed");
+        assert_eq!(decoded, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn scalar_buffer_try_to_vec_rejects_dtype_mismatch() {
+        let values = ScalarBuffer::from_bytes(
+            DType::I64,
+            [1i64].into_iter().flat_map(i64::to_ne_bytes).collect(),
+        )
+        .expect("valid scalar buffer should be created");
+
+        let err = values
+            .try_to_vec::<f32>()
+            .expect_err("dtype mismatch should fail");
+        assert_eq!(
+            err,
+            ScalarBufferDecodeError::DTypeMismatch {
+                expected: DType::F32,
+                actual: DType::I64
+            }
+        );
+    }
+
+    #[test]
+    fn stack_vector_can_be_built_from_scalar_buffer() {
+        let values = ScalarBuffer::from_bytes(
+            DType::I64,
+            [4i64, 5, 6]
+                .into_iter()
+                .flat_map(i64::to_ne_bytes)
+                .collect::<Vec<u8>>(),
+        )
+        .expect("valid scalar buffer should be created");
+
+        let stack = StackVector::<i64, 8>::try_from_scalar_buffer(&values)
+            .expect("stack vector decode should succeed");
+        assert_eq!(stack.as_slice(), &[4, 5, 6]);
     }
 
     #[test]

--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -9,6 +9,7 @@ mod scalar;
 mod scalar_buffer;
 mod stack_vector;
 mod value;
+mod view_spec;
 
 pub use arg::KernelArg;
 pub use args::KernelArgs;
@@ -21,12 +22,13 @@ pub use scalar::Scalar;
 pub use scalar_buffer::{ScalarBuffer, ScalarBufferDecodeError, ScalarBufferElement};
 pub use stack_vector::{StackVector, StackVectorError};
 pub use value::{ArgKind, ArgValue, ArgValueAccess, StorageValue};
+pub use view_spec::{ViewSpec, ViewSpecError};
 
 #[cfg(test)]
 mod tests {
     use super::{
         ArgKey, ArgKind, ArgRole, DType, KernelArg, KernelArgs, KernelArgsError, Scalar,
-        ScalarBuffer, ScalarBufferDecodeError, StackVector, StorageValue,
+        ScalarBuffer, ScalarBufferDecodeError, StackVector, StorageValue, ViewSpec,
     };
 
     #[test]
@@ -236,6 +238,20 @@ mod tests {
         let stack = StackVector::<i64, 8>::try_from_scalar_buffer(&values)
             .expect("stack vector decode should succeed");
         assert_eq!(stack.as_slice(), &[4, 5, 6]);
+    }
+
+    #[test]
+    fn kernel_args_insert_and_require_view_spec() {
+        let mut args: KernelArgs<()> = KernelArgs::new();
+        let key = ArgKey::new(ArgRole::Param, "view", ArgKind::ViewSpec);
+        let view = ViewSpec::new(vec![2, 3], vec![3, 1], 4).expect("view should be valid");
+        args.insert_view_spec(key.clone(), view.clone())
+            .expect("view spec insertion should succeed");
+
+        let got = args
+            .require_view_spec(&key)
+            .expect("view spec retrieval should succeed");
+        assert_eq!(got, &view);
     }
 
     #[test]

--- a/schema/src/scalar_buffer.rs
+++ b/schema/src/scalar_buffer.rs
@@ -56,4 +56,83 @@ impl ScalarBuffer {
         let end = start.checked_add(element_size)?;
         self.dtype.decode_scalar(&self.bytes[start..end])
     }
+
+    pub fn try_to_vec<T>(&self) -> Result<Vec<T>, ScalarBufferDecodeError>
+    where
+        T: ScalarBufferElement,
+    {
+        if self.dtype != T::DTYPE {
+            return Err(ScalarBufferDecodeError::DTypeMismatch {
+                expected: T::DTYPE,
+                actual: self.dtype,
+            });
+        }
+
+        let mut values = Vec::with_capacity(self.len);
+        for index in 0..self.len {
+            let scalar = self
+                .scalar_at(index)
+                .ok_or(ScalarBufferDecodeError::DecodeFailed { index })?;
+            let value =
+                T::from_scalar(scalar).ok_or(ScalarBufferDecodeError::DecodeFailed { index })?;
+            values.push(value);
+        }
+        Ok(values)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScalarBufferDecodeError {
+    DTypeMismatch { expected: DType, actual: DType },
+    DecodeFailed { index: usize },
+}
+
+pub trait ScalarBufferElement: Sized {
+    const DTYPE: DType;
+
+    fn from_scalar(value: Scalar) -> Option<Self>;
+}
+
+impl ScalarBufferElement for f32 {
+    const DTYPE: DType = DType::F32;
+
+    fn from_scalar(value: Scalar) -> Option<Self> {
+        match value {
+            Scalar::F32(v) => Some(v),
+            _ => None,
+        }
+    }
+}
+
+impl ScalarBufferElement for i64 {
+    const DTYPE: DType = DType::I64;
+
+    fn from_scalar(value: Scalar) -> Option<Self> {
+        match value {
+            Scalar::I64(v) => Some(v),
+            _ => None,
+        }
+    }
+}
+
+impl ScalarBufferElement for u8 {
+    const DTYPE: DType = DType::U8;
+
+    fn from_scalar(value: Scalar) -> Option<Self> {
+        match value {
+            Scalar::U8(v) => Some(v),
+            _ => None,
+        }
+    }
+}
+
+impl ScalarBufferElement for bool {
+    const DTYPE: DType = DType::Bool;
+
+    fn from_scalar(value: Scalar) -> Option<Self> {
+        match value {
+            Scalar::Bool(v) => Some(v),
+            _ => None,
+        }
+    }
 }

--- a/schema/src/stack_vector.rs
+++ b/schema/src/stack_vector.rs
@@ -1,0 +1,157 @@
+use crate::{ScalarBuffer, ScalarBufferDecodeError, ScalarBufferElement};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub struct StackVector<T, const MAX_LEN: usize> {
+    len: u32,
+    data: [T; MAX_LEN],
+}
+
+impl<T, const MAX_LEN: usize> StackVector<T, MAX_LEN>
+where
+    T: Copy + Default,
+{
+    pub fn len(&self) -> usize {
+        usize::try_from(self.len).expect("u32 length must fit into usize")
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    pub fn as_slice(&self) -> &[T] {
+        &self.data[..self.len()]
+    }
+
+    pub fn capacity(&self) -> usize {
+        MAX_LEN
+    }
+
+    pub fn try_from_slice(values: &[T]) -> Result<Self, StackVectorError> {
+        if values.len() > MAX_LEN {
+            return Err(StackVectorError::TooLong {
+                len: values.len(),
+                max_len: MAX_LEN,
+            });
+        }
+        let len = u32::try_from(values.len())
+            .map_err(|_| StackVectorError::LengthOverflow { len: values.len() })?;
+
+        let mut data = [T::default(); MAX_LEN];
+        data[..values.len()].copy_from_slice(values);
+        Ok(Self { len, data })
+    }
+
+    pub fn try_from_scalar_buffer(buffer: &ScalarBuffer) -> Result<Self, StackVectorError>
+    where
+        T: ScalarBufferElement,
+    {
+        let values = buffer
+            .try_to_vec::<T>()
+            .map_err(StackVectorError::ScalarBufferDecode)?;
+        Self::try_from_slice(&values)
+    }
+}
+
+impl<T, const MAX_LEN: usize> Default for StackVector<T, MAX_LEN>
+where
+    T: Copy + Default,
+{
+    fn default() -> Self {
+        Self {
+            len: 0,
+            data: [T::default(); MAX_LEN],
+        }
+    }
+}
+
+impl ScalarBuffer {
+    pub fn try_to_stack_vector<T, const MAX_LEN: usize>(
+        &self,
+    ) -> Result<StackVector<T, MAX_LEN>, StackVectorError>
+    where
+        T: Copy + Default + ScalarBufferElement,
+    {
+        StackVector::try_from_scalar_buffer(self)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StackVectorError {
+    TooLong { len: usize, max_len: usize },
+    LengthOverflow { len: usize },
+    ScalarBufferDecode(ScalarBufferDecodeError),
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{DType, ScalarBuffer};
+
+    use super::{StackVector, StackVectorError};
+
+    #[test]
+    fn try_from_scalar_buffer_succeeds_for_matching_dtype() {
+        let buffer = ScalarBuffer::from_bytes(
+            DType::I64,
+            [1i64, 2, 3]
+                .into_iter()
+                .flat_map(i64::to_ne_bytes)
+                .collect::<Vec<u8>>(),
+        )
+        .expect("valid scalar buffer should be created");
+
+        let values = StackVector::<i64, 4>::try_from_scalar_buffer(&buffer)
+            .expect("i64 stack vector decoding should succeed");
+        assert_eq!(values.len(), 3);
+        assert_eq!(values.as_slice(), &[1, 2, 3]);
+    }
+
+    #[test]
+    fn try_from_scalar_buffer_rejects_dtype_mismatch() {
+        let buffer = ScalarBuffer::from_bytes(
+            DType::I64,
+            [1i64].into_iter().flat_map(i64::to_ne_bytes).collect(),
+        )
+        .expect("valid scalar buffer should be created");
+
+        let err = StackVector::<f32, 4>::try_from_scalar_buffer(&buffer)
+            .expect_err("dtype mismatch should fail");
+        assert!(matches!(
+            err,
+            StackVectorError::ScalarBufferDecode(crate::ScalarBufferDecodeError::DTypeMismatch {
+                expected: DType::F32,
+                actual: DType::I64
+            })
+        ));
+    }
+
+    #[test]
+    fn try_from_scalar_buffer_rejects_too_long_input() {
+        let buffer = ScalarBuffer::from_bytes(
+            DType::I64,
+            [1i64, 2, 3]
+                .into_iter()
+                .flat_map(i64::to_ne_bytes)
+                .collect::<Vec<u8>>(),
+        )
+        .expect("valid scalar buffer should be created");
+
+        let err = StackVector::<i64, 2>::try_from_scalar_buffer(&buffer)
+            .expect_err("longer-than-capacity input should fail");
+        assert_eq!(err, StackVectorError::TooLong { len: 3, max_len: 2 });
+    }
+
+    #[test]
+    fn scalar_buffer_can_decode_to_stack_vector_directly() {
+        let buffer = ScalarBuffer::from_bytes(
+            DType::I64,
+            [7i64, 8].into_iter().flat_map(i64::to_ne_bytes).collect(),
+        )
+        .expect("valid scalar buffer should be created");
+
+        let values = buffer
+            .try_to_stack_vector::<i64, 4>()
+            .expect("direct stack vector decode should succeed");
+        assert_eq!(values.as_slice(), &[7, 8]);
+    }
+}

--- a/schema/src/value.rs
+++ b/schema/src/value.rs
@@ -1,4 +1,4 @@
-use crate::{DType, Scalar, ScalarBuffer};
+use crate::{DType, Scalar, ScalarBuffer, ViewSpec};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ArgKind {
@@ -6,6 +6,7 @@ pub enum ArgKind {
     ScalarBuffer,
     Scalar(DType),
     Usize,
+    ViewSpec,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
@@ -17,6 +18,7 @@ pub enum ArgValue<S> {
     ScalarBuffer(ScalarBuffer),
     Scalar(Scalar),
     Usize(usize),
+    ViewSpec(ViewSpec),
 }
 
 impl<S> ArgValue<S> {
@@ -26,6 +28,7 @@ impl<S> ArgValue<S> {
             Self::ScalarBuffer(_) => ArgKind::ScalarBuffer,
             Self::Scalar(v) => v.arg_kind(),
             Self::Usize(_) => ArgKind::Usize,
+            Self::ViewSpec(_) => ArgKind::ViewSpec,
         }
     }
 }
@@ -170,6 +173,25 @@ impl<S> ArgValueAccess<S> for bool {
     {
         match value {
             ArgValue::Scalar(Scalar::Bool(v)) => Some(v),
+            _ => None,
+        }
+    }
+}
+
+impl<S> ArgValueAccess<S> for ViewSpec {
+    type Ref<'a>
+        = &'a ViewSpec
+    where
+        S: 'a;
+
+    const KIND: ArgKind = ArgKind::ViewSpec;
+
+    fn get<'a>(value: &'a ArgValue<S>) -> Option<Self::Ref<'a>>
+    where
+        S: 'a,
+    {
+        match value {
+            ArgValue::ViewSpec(v) => Some(v),
             _ => None,
         }
     }

--- a/schema/src/view_spec.rs
+++ b/schema/src/view_spec.rs
@@ -47,6 +47,67 @@ impl ViewSpec {
             .ok_or(ViewSpecError::NumelOverflow)
     }
 
+    pub fn checked_pos(&self, indices: &[usize]) -> Result<usize, ViewSpecError> {
+        if indices.len() != self.rank() {
+            return Err(ViewSpecError::IndicesRankMismatch {
+                expected_rank: self.rank(),
+                actual_rank: indices.len(),
+            });
+        }
+
+        let mut pos = self.offset;
+        for (dim, (&index, (&size, &stride))) in indices
+            .iter()
+            .zip(self.shape.iter().zip(self.strides.iter()))
+            .enumerate()
+        {
+            if index >= size {
+                return Err(ViewSpecError::IndexOutOfBounds { dim, index, size });
+            }
+            let step = index
+                .checked_mul(stride)
+                .ok_or(ViewSpecError::PositionOverflow)?;
+            pos = pos
+                .checked_add(step)
+                .ok_or(ViewSpecError::PositionOverflow)?;
+        }
+
+        Ok(pos)
+    }
+
+    pub fn checked_pos_i64(&self, indices: &[i64]) -> Result<usize, ViewSpecError> {
+        if indices.len() != self.rank() {
+            return Err(ViewSpecError::IndicesRankMismatch {
+                expected_rank: self.rank(),
+                actual_rank: indices.len(),
+            });
+        }
+
+        let mut pos = self.offset;
+        for (dim, (&raw_index, (&size, &stride))) in indices
+            .iter()
+            .zip(self.shape.iter().zip(self.strides.iter()))
+            .enumerate()
+        {
+            let index =
+                usize::try_from(raw_index).map_err(|_| ViewSpecError::IndexValueOutOfRange {
+                    dim,
+                    index: raw_index,
+                })?;
+            if index >= size {
+                return Err(ViewSpecError::IndexOutOfBounds { dim, index, size });
+            }
+            let step = index
+                .checked_mul(stride)
+                .ok_or(ViewSpecError::PositionOverflow)?;
+            pos = pos
+                .checked_add(step)
+                .ok_or(ViewSpecError::PositionOverflow)?;
+        }
+
+        Ok(pos)
+    }
+
     pub fn numel(&self) -> Option<usize> {
         self.checked_numel().ok()
     }
@@ -59,6 +120,20 @@ pub enum ViewSpecError {
         strides_rank: usize,
     },
     NumelOverflow,
+    IndicesRankMismatch {
+        expected_rank: usize,
+        actual_rank: usize,
+    },
+    IndexOutOfBounds {
+        dim: usize,
+        index: usize,
+        size: usize,
+    },
+    IndexValueOutOfRange {
+        dim: usize,
+        index: i64,
+    },
+    PositionOverflow,
 }
 
 #[cfg(test)]
@@ -82,5 +157,46 @@ mod tests {
         let spec = ViewSpec::new(vec![usize::MAX, 2], vec![1, 1], 0)
             .expect("rank-matched shape/strides should construct");
         assert_eq!(spec.checked_numel(), Err(ViewSpecError::NumelOverflow));
+    }
+
+    #[test]
+    fn checked_pos_validates_rank_and_bounds() {
+        let spec = ViewSpec::new(vec![2, 3], vec![3, 1], 4).expect("view should be valid");
+
+        assert_eq!(spec.checked_pos(&[1, 2]), Ok(9));
+        assert_eq!(
+            spec.checked_pos(&[1]),
+            Err(ViewSpecError::IndicesRankMismatch {
+                expected_rank: 2,
+                actual_rank: 1
+            })
+        );
+        assert_eq!(
+            spec.checked_pos(&[2, 0]),
+            Err(ViewSpecError::IndexOutOfBounds {
+                dim: 0,
+                index: 2,
+                size: 2
+            })
+        );
+    }
+
+    #[test]
+    fn checked_pos_i64_validates_conversion_and_bounds() {
+        let spec = ViewSpec::new(vec![2, 3], vec![3, 1], 4).expect("view should be valid");
+
+        assert_eq!(spec.checked_pos_i64(&[1, 2]), Ok(9));
+        assert_eq!(
+            spec.checked_pos_i64(&[-1, 0]),
+            Err(ViewSpecError::IndexValueOutOfRange { dim: 0, index: -1 })
+        );
+        assert_eq!(
+            spec.checked_pos_i64(&[2, 0]),
+            Err(ViewSpecError::IndexOutOfBounds {
+                dim: 0,
+                index: 2,
+                size: 2
+            })
+        );
     }
 }

--- a/schema/src/view_spec.rs
+++ b/schema/src/view_spec.rs
@@ -1,0 +1,86 @@
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ViewSpec {
+    shape: Vec<usize>,
+    strides: Vec<usize>,
+    offset: usize,
+}
+
+impl ViewSpec {
+    pub fn new(
+        shape: Vec<usize>,
+        strides: Vec<usize>,
+        offset: usize,
+    ) -> Result<Self, ViewSpecError> {
+        if shape.len() != strides.len() {
+            return Err(ViewSpecError::RankMismatch {
+                shape_rank: shape.len(),
+                strides_rank: strides.len(),
+            });
+        }
+        Ok(Self {
+            shape,
+            strides,
+            offset,
+        })
+    }
+
+    pub fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    pub fn strides(&self) -> &[usize] {
+        &self.strides
+    }
+
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    pub fn rank(&self) -> usize {
+        self.shape.len()
+    }
+
+    pub fn checked_numel(&self) -> Result<usize, ViewSpecError> {
+        self.shape
+            .iter()
+            .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
+            .ok_or(ViewSpecError::NumelOverflow)
+    }
+
+    pub fn numel(&self) -> Option<usize> {
+        self.checked_numel().ok()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ViewSpecError {
+    RankMismatch {
+        shape_rank: usize,
+        strides_rank: usize,
+    },
+    NumelOverflow,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ViewSpec, ViewSpecError};
+
+    #[test]
+    fn new_rejects_rank_mismatch() {
+        let err = ViewSpec::new(vec![2, 3], vec![3], 0).expect_err("rank mismatch should fail");
+        assert_eq!(
+            err,
+            ViewSpecError::RankMismatch {
+                shape_rank: 2,
+                strides_rank: 1
+            }
+        );
+    }
+
+    #[test]
+    fn checked_numel_detects_overflow() {
+        let spec = ViewSpec::new(vec![usize::MAX, 2], vec![1, 1], 0)
+            .expect("rank-matched shape/strides should construct");
+        assert_eq!(spec.checked_numel(), Err(ViewSpecError::NumelOverflow));
+    }
+}


### PR DESCRIPTION
## タイトル

Refactor ops: introduce ViewSpec-based indexing and view-aware fill/at kernels

## 説明

このPRでは、テンソルのビュー情報を一元的に扱うための ViewSpec を導入し、それに伴って at / fill 系の実装をリファクタリングしました。

### 主な変更点

- schema
  - ArgKind に ViewSpec を追加し、KernelArg / KernelArgs で ViewSpec を扱えるように追加
  - ScalarBuffer に型付きデコード用の try_to_vec と、それを支える ScalarBufferElement / ScalarBufferDecodeError を追加
  - ScalarBuffer から固定長スタック配列にデコードする StackVector と、そのユーティリティ・テストを追加
  - ViewSpec 構造体および ViewSpecError を追加し、shape / strides / offset から
    - checked_numel (要素数の検証付き計算)
    - checked_pos / checked_pos_i64 (インデックスからの位置計算＋境界チェック・オーバーフロー検出)
    を提供

- core/dense_impl
  - DenseTensorImpl に view_spec() を追加し、shape / strides / offset から ViewSpec を生成
  - at:
    - これまでの validated_pos による usize 位置計算を廃止し、
      ViewSpec と indices(i64バッファ)をカーネルに渡してポジション計算を行うよう変更
    - カーネル引数として pos(usize) ではなく view_spec と indices(ScalarBuffer) を使用
    - エラー型を ViewSpecError / indices エンコードエラーに対応するものに整理
  - fill:
    - is_packed 判定による分岐と手書きの flat_to_pos ベースの CPU 実装を削除
    - すべて ViewSpec を渡す cpu.fill カーネル経由の実行に統一
    - エラー型に InvalidViewSpec を追加し、ビュー情報の検証エラーを明示的に扱うよう変更

- execution_cpu
  - cpu.fill:
    - ViewSpec を必須のパラメータとして受け取り、checked_numel と flat_to_pos 相当のロジックで
      ビュー上の要素のみを走査して fill するように変更
    - これにより、ストライド付きビューやオフセット付きビューに対しても安全に部分 fill が可能
    - 既存テストを ViewSpec 前提の形に書き換え、ビュー領域のみが書き換わるテストや、
      不正な ViewSpec に対する検証テストを追加
  - cpu.read_at / cpu.write_at:
    - 位置引数 pos(usize) を廃止し、代わりに
      - ViewSpec (shape/strides/offset)
      - indices(ScalarBuffer; I64 として decode)
      を受け取り、ViewSpec::checked_pos_i64 によってポジションを計算
    - indices のデコードエラーや境界外アクセスなどをメッセージに含めるようエラーハンドリングを改善
    - テストを ViewSpec / ScalarBuffer ベースに書き換え、IndexOutOfBounds などのエラー内容を検証

- runtime
  - ArgKind::ViewSpec を v2 resolver でシリアライズ対象として追加

### 目的 / モチベーション

- テンソルのビュー（shape / strides / offset）を ViewSpec として明示的に扱うことで、
  - at / fill / read_at / write_at などの演算をビュー対応にしやすくする
  - インデックス計算ロジックを一箇所に集約し、安全性（rank mismatch / out-of-bounds / overflow）の検証を強化する
- ScalarBuffer からの型安全なデコードと StackVector を導入することで、
  - カーネル引数として渡されるメタデータ（インデックス列など）の取り回しを簡潔かつ安全にする

### 影響範囲

- ViewSpec を前提にすることで、既存のカーネル呼び出しパスのシグネチャが一部変わっています。
  - at / fill / read_at / write_at の呼び出し側は、すべて ViewSpec と indices(必要な場合) を渡す形に更新済みです。
- ViewSpec と ScalarBuffer の新しい API については、テストを追加済みで基本的なユースケースと
  エラーケースの動作をカバーしています。

レビューでは以下を特に見てほしいです。

- ViewSpec の API / エラー設計（checked_numel, checked_pos(_i64) の振る舞いが妥当か）
- cpu.fill / cpu.read_at / cpu.write_at のエラーメッセージと検証ロジックが十分かどうか
- ScalarBuffer::try_to_vec と StackVector 周りの API 形状・名前付けが今後の拡張にとって自然か